### PR TITLE
fix: 部分游戏公告点不开

### DIFF
--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -413,6 +413,10 @@ namespace XIVLauncher.Windows
             {
                 Process.Start(new ProcessStartInfo(item.Url) { UseShellExecute = true });
             }
+            else if (!string.IsNullOrEmpty(item.Id))
+            {
+                Process.Start(new ProcessStartInfo($"https://ff.web.sdo.com/web8/index.html#/newstab/newscont/{item.Id}") { UseShellExecute = true });
+            }
             //else
             //{
             //    string url;


### PR DESCRIPTION
自从上了新启动器，旧的 API 都不返回链接了，这里做个 fallback