### PR TITLE
修复按钮颜色，修改信息框标题

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -327,7 +327,7 @@ namespace XIVLauncher
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Could not set up logging. Please report this error.\n\n" + ex.Message, "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("Could not set up logging. Please report this error.\n\n" + ex.Message, "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error);
             }
 
             try
@@ -378,7 +378,7 @@ namespace XIVLauncher
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Could not parse command line arguments. Please report this error.\n\n" + ex.Message, "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show("Could not parse command line arguments. Please report this error.\n\n" + ex.Message, "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error);
             }
 
             try

--- a/src/XIVLauncher/Game/ProblemCheck.cs
+++ b/src/XIVLauncher/Game/ProblemCheck.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -42,7 +42,7 @@ namespace XIVLauncher.Game
                     var result = CustomMessageBox.Show(
                         Loc.Localize("AdminCheck",
                             "XIVLauncher and/or the game are set to run as administrator.\nThis can cause various issues, including addons failing to launch and hotkey applications failing to respond.\n\nDo you want to fix this issue automatically?"),
-                        "XIVLauncherCN", MessageBoxButton.OKCancel, MessageBoxImage.Exclamation, parentWindow: parentWindow);
+                        "XIVLauncherCN (Soil)", MessageBoxButton.OKCancel, MessageBoxImage.Exclamation, parentWindow: parentWindow);
 
                     if (result != MessageBoxResult.OK)
                         return;

--- a/src/XIVLauncher/Updates.cs
+++ b/src/XIVLauncher/Updates.cs
@@ -197,14 +197,14 @@ internal class Updates
             {
                 CustomMessageBox.Show($"错误: GitHub 服务器返回错误代码 {httpRequestException.StatusCode}.\n" +
                                       Environment.NewLine                                          + updateFailLoc,
-                                      "XIVLauncherCN",
+                                      "XIVLauncherCN (Soil)",
                                       MessageBoxButton.OK,
                                       MessageBoxImage.Error, showOfficialLauncher: true);
             }
             else
             {
                 CustomMessageBox.Show($"错误: {ex.Message}" + Environment.NewLine + updateFailLoc,
-                                      "XIVLauncherCN",
+                                      "XIVLauncherCN (Soil)",
                                       MessageBoxButton.OK,
                                       MessageBoxImage.Error, showOfficialLauncher: true);
             }
@@ -213,7 +213,7 @@ internal class Updates
             {
                 var result = CustomMessageBox.Show("无法检查更新, 根据你的设置, 是否继续使用当前版本?\n" +
                                                    "请注意: 这说明你当前可能无法连接 Github, 即使进入 XIVLauncher 也无法完成 Dalamud 的更新检查与下载",
-                                                   "XIVLauncherCN",
+                                                   "XIVLauncherCN (Soil)",
                                                    MessageBoxButton.YesNo,
                                                    MessageBoxImage.Question,
                                                    showDiscordLink: false,

--- a/src/XIVLauncher/Windows/ChangelogWindow.xaml
+++ b/src/XIVLauncher/Windows/ChangelogWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="XIVLauncher.Windows.ChangelogWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -27,7 +27,7 @@
                     <TextBlock Margin="10" MaxWidth="650" Height="Auto" x:Name="ChangeLogText" TextWrapping="Wrap"></TextBlock>
                 </StackPanel>
 
-                <materialDesign:PackIcon Kind="Globe" HorizontalAlignment="Stretch" Foreground="DarkOrange"
+                <materialDesign:PackIcon Kind="Globe" HorizontalAlignment="Stretch" Foreground="{DynamicResource PrimaryHueMidBrush}"
                                          VerticalAlignment="Stretch" Width="30" Height="30" Margin="10,0,20,0" />
             </StackPanel>
         </StackPanel>

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
@@ -320,7 +320,7 @@ namespace XIVLauncher.Windows
         public class Builder
         {
             internal string Text;
-            internal string Caption = "XIVLauncherCN";
+            internal string Caption = "XIVLauncherCN (Soil)";
             internal string Description;
             internal MessageBoxButton Buttons = MessageBoxButton.OK;
             internal MessageBoxResult DefaultResult = MessageBoxResult.None;  // On enter

--- a/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
@@ -31,13 +31,13 @@ namespace XIVLauncher.Windows
             try
             {
                 var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory); //获取桌面文件夹路径
-                CreateShortcut(desktop, "XIVLauncherCN", Path.Combine(new DirectoryInfo(Environment.CurrentDirectory).Parent.FullName, "XIVLauncherCN.exe"));
+                CreateShortcut(desktop, "XIVLauncherCN (Soil)", Path.Combine(new DirectoryInfo(Environment.CurrentDirectory).Parent.FullName, "XIVLauncherCN.exe"));
             }
             catch
             {
                 CustomMessageBox.Show(
                     $"创建快捷方式失败，如需要请手动创建快捷方式到桌面。",
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: this);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: this);
             }
         }
 
@@ -63,7 +63,7 @@ namespace XIVLauncher.Windows
         public static string GetShortcutTargetFile(string path)
         {
             var shell = new WshShell();
-            var shortcut = (IWshShortcut) shell.CreateShortcut(path);
+            var shortcut = (IWshShortcut)shell.CreateShortcut(path);
 
             return shortcut.TargetPath;
         }
@@ -88,7 +88,7 @@ namespace XIVLauncher.Windows
 
                 if (!GameHelpers.IsValidGamePath(GamePathEntry.Text))
                 {
-                    if (CustomMessageBox.Show(Loc.Localize("GamePathInvalidConfirm", "The folder you selected has no installation of the game.\nXIVLauncher will install the game the first time you log in.\nContinue?"), "XIVLauncherCN",
+                    if (CustomMessageBox.Show(Loc.Localize("GamePathInvalidConfirm", "The folder you selected has no installation of the game.\nXIVLauncher will install the game the first time you log in.\nContinue?"), "XIVLauncherCN (Soil)",
                             MessageBoxButton.YesNo, MessageBoxImage.Information, parentWindow: this) != MessageBoxResult.Yes)
                     {
                         return;
@@ -106,7 +106,7 @@ namespace XIVLauncher.Windows
 
                 if (GamePathEntry.Text.StartsWith("C"))
                 {
-                    if (CustomMessageBox.Show("你选择的游戏路径位于C盘。\nXIVLauncher将会无法正常登陆，请将游戏移出C盘或者使用管理员启动XIVLauncher。", "XIVLauncherCN",
+                    if (CustomMessageBox.Show("你选择的游戏路径位于C盘。\nXIVLauncher将会无法正常登陆，请将游戏移出C盘或者使用管理员启动XIVLauncher。", "XIVLauncherCN (Soil)",
                         MessageBoxButton.YesNo, MessageBoxImage.Warning, parentWindow: this) != MessageBoxResult.Yes)
                     {
                         return;
@@ -117,7 +117,7 @@ namespace XIVLauncher.Windows
             if (SetupTabControl.SelectedIndex == 2)
             {
                 App.Settings.GamePath = new DirectoryInfo(GamePathEntry.Text);
-                App.Settings.Language = (ClientLanguage) LanguageComboBox.SelectedIndex;
+                App.Settings.Language = (ClientLanguage)LanguageComboBox.SelectedIndex;
                 App.Settings.InGameAddonEnabled = HooksCheckBox.IsChecked == true;
 
                 App.Settings.AddonList = new List<AddonEntry>();

--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -488,8 +488,6 @@
                                                 <Button HorizontalAlignment="Left"
                                                         Visibility="Visible"
                                                         x:Name="AccountSwitcherButton" Margin="0 0 0 0"
-                                                        Background="Orange"
-                                                        BorderBrush="DarkOrange"
                                                         ToolTip="{Binding OpenAccountSwitcherLoc}"
                                                         Click="AccountSwitcherButton_OnClick">
                                                     <StackPanel Orientation="Horizontal" Margin="0">

--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -520,8 +520,6 @@
                                             <Button HorizontalAlignment="Center"
                                                         Visibility="Visible"
                                                         x:Name="BackToMain" Margin="0 0 0 0"
-                                                        Background="#FF0096DB"
-                                                        BorderBrush="#FF0096DB"
                                                         ToolTip="返回登录页面"
                                                         Click="BackToLoginPageButton_OnClick">
                                                 <StackPanel Orientation="Horizontal" Margin="0">
@@ -571,7 +569,7 @@
                                                     </DataTemplate>
                                                 </ComboBox.ItemTemplate>
                                             </ComboBox>
-  
+
                                             <StackPanel Orientation="Horizontal"
                                                         HorizontalAlignment="Center"
                                                         VerticalAlignment="Bottom"

--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -514,7 +514,7 @@ namespace XIVLauncher.Windows
                 if (hasBootPatch)
                 {
                     CustomMessageBox.Show(Loc.Localize("MaintenanceQueueBootPatch",
-                        "A patch for the official launcher was detected.\nThis usually means that there is a patch for the game as well.\n\nYou will now be logged in."), "XIVLauncherCN", parentWindow: this);
+                        "A patch for the official launcher was detected.\nThis usually means that there is a patch for the game as well.\n\nYou will now be logged in."), "XIVLauncherCN (Soil)", parentWindow: this);
                 }
 
                 Dispatcher.Invoke(() =>

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -258,7 +258,7 @@ namespace XIVLauncher.Windows
 
             if (Repository.Ffxiv.IsBaseVer(gamePath))
             {
-                CustomMessageBox.Show(Loc.Localize("IntegrityCheckBase", "The game is not installed to the path you specified.\nPlease install the game before running an integrity check."), "XIVLauncherCN", parentWindow: Window.GetWindow(this));
+                CustomMessageBox.Show(Loc.Localize("IntegrityCheckBase", "The game is not installed to the path you specified.\nPlease install the game before running an integrity check."), "XIVLauncherCN (Soil)", parentWindow: Window.GetWindow(this));
                 return;
             }
 
@@ -279,23 +279,23 @@ namespace XIVLauncher.Windows
                         case IntegrityCheck.CompareResult.ReferenceNotFound:
                             CustomMessageBox.Show(Loc.Localize("IntegrityCheckImpossible",
                                     "There is no reference report yet for this game version. Please try again later."),
-                                "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
+                                "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
                             return;
 
                         case IntegrityCheck.CompareResult.ReferenceFetchFailure:
                             CustomMessageBox.Show(Loc.Localize("IntegrityCheckNetworkError",
                                     "Failed to download reference files for checking integrity. Check your internet connection and try again."),
-                                "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: Window.GetWindow(this));
+                                "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: Window.GetWindow(this));
                             return;
 
                         case IntegrityCheck.CompareResult.Invalid:
                             CustomMessageBox.Show(Loc.Localize("IntegrityCheckFailed",
                                     "Some game files seem to be modified or corrupted. \n\nIf you use TexTools mods, this is an expected result.\n\nIf you do not use mods, right click the \"Login\" button on the XIVLauncher start page and choose \"Repair game\"."),
-                                "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, showReportLinks: true, parentWindow: Window.GetWindow(this));
+                                "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, showReportLinks: true, parentWindow: Window.GetWindow(this));
                             break;
 
                         case IntegrityCheck.CompareResult.Valid:
-                            CustomMessageBox.Show(Loc.Localize("IntegrityCheckValid", "Your game install seems to be valid."), "XIVLauncherCN", MessageBoxButton.OK,
+                            CustomMessageBox.Show(Loc.Localize("IntegrityCheckValid", "Your game install seems to be valid."), "XIVLauncherCN (Soil)", MessageBoxButton.OK,
                                 MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
                             break;
                     }
@@ -315,7 +315,7 @@ namespace XIVLauncher.Windows
 
             if (Repository.Ffxiv.IsBaseVer(gamePath))
             {
-                CustomMessageBox.Show(Loc.Localize("IntegrityCheckBase", "The game is not installed to the path you specified.\nPlease install the game before running an integrity check."), "XIVLauncherCN", parentWindow: Window.GetWindow(this));
+                CustomMessageBox.Show(Loc.Localize("IntegrityCheckBase", "The game is not installed to the path you specified.\nPlease install the game before running an integrity check."), "XIVLauncherCN (Soil)", parentWindow: Window.GetWindow(this));
                 return;
             }
             
@@ -326,7 +326,7 @@ namespace XIVLauncher.Windows
                 this.Dispatcher.Invoke(() =>
                 {
                     CustomMessageBox.Show("已完成游戏客户端哈希数据生成, 相关文件保存在:\n" + 
-                                          $"{task.Result}", "XIVLauncherCN", parentWindow: Window.GetWindow(this));
+                                          $"{task.Result}", "XIVLauncherCN (Soil)", parentWindow: Window.GetWindow(this));
                 });
             });
 
@@ -341,7 +341,7 @@ namespace XIVLauncher.Windows
                 {
                     CustomMessageBox.Show(
                         Loc.Localize("DalamudIncompatible", "Dalamud was not yet updated for your current game version.\nThis is common after patches, so please be patient or ask on the Discord for a status update!"),
-                        "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
+                        "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
                 }
             }
             catch (Exception exc)
@@ -457,7 +457,7 @@ namespace XIVLauncher.Windows
             if (App.Steam.AsyncStartTask != null)
             {
                 CustomMessageBox.Show(Loc.Localize("SteamFtToggleAutoStartWarning", "To apply this setting, XIVLauncher needs to restart.\nPlease reopen XIVLauncher."),
-                                      "XIVLauncherCN", image: MessageBoxImage.Information, showDiscordLink: false, showHelpLinks: false);
+                                      "XIVLauncherCN (Soil)", image: MessageBoxImage.Information, showDiscordLink: false, showHelpLinks: false);
                 App.Settings.IsFt = IsFreeTrialCheckbox.IsChecked == true;
                 CloseMainWindowGracefully?.Invoke(this, null);
             }

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -324,7 +324,7 @@ namespace XIVLauncher.Windows.ViewModel
 
                 if (bootver > cutoff)
                 {
-                    CustomMessageBox.Show(cutoffText, "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.None, showHelpLinks: false, showDiscordLink: true, showOfficialLauncher: true);
+                    CustomMessageBox.Show(cutoffText, "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.None, showHelpLinks: false, showDiscordLink: true, showOfficialLauncher: true);
 
                     Environment.Exit(0);
                     return;
@@ -335,7 +335,7 @@ namespace XIVLauncher.Windows.ViewModel
             {
                 CustomMessageBox.Show(
                     "未能获取到服务器列表,无法登陆",
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
                 return;
             }
 
@@ -1010,7 +1010,7 @@ namespace XIVLauncher.Windows.ViewModel
             {
                 CustomMessageBox.Show(
                     Loc.Localize("LoginNoStartOk",
-                        "An update check was executed and any pending updates were installed."), "XIVLauncherCN",
+                        "An update check was executed and any pending updates were installed."), "XIVLauncherCN (Soil)",
                     MessageBoxButton.OK, MessageBoxImage.Information, showHelpLinks: false, showDiscordLink: false, parentWindow: _window);
 
                 return false;
@@ -1021,7 +1021,7 @@ namespace XIVLauncher.Windows.ViewModel
                 Log.Error("loginResult.State == NeedRetry");
                 CustomMessageBox.Show(
                     Loc.Localize("LoginNeedRetry",
-                                 "登录失败,建议尝试重新扫码登录."), "XIVLauncherCN",
+                                 "登录失败,建议尝试重新扫码登录."), "XIVLauncherCN (Soil)",
                     MessageBoxButton.OK, MessageBoxImage.Information, showHelpLinks: false, showDiscordLink: false, parentWindow: _window);
                 return false;
             }
@@ -1413,7 +1413,7 @@ namespace XIVLauncher.Windows.ViewModel
             }
             else
             {
-                CustomMessageBox.Show(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."), "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
+                CustomMessageBox.Show(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."), "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
             }
 
             return doLogin;
@@ -1580,7 +1580,7 @@ namespace XIVLauncher.Windows.ViewModel
                         var dialog = CustomMessageBox.Builder
                         .NewFrom("当前选择的进程已经注入了")
                         .WithButtons(MessageBoxButton.OK)
-                        .WithCaption("XIVLauncherCN")
+                        .WithCaption("XIVLauncherCN (Soil)")
                         .WithParentWindow(_window)
                         .Show();
                     }
@@ -1592,7 +1592,7 @@ namespace XIVLauncher.Windows.ViewModel
                             var dialog = CustomMessageBox.Builder
                                 .NewFrom("注入完成,是否退出XIVLauncherCN?")
                                 .WithButtons(MessageBoxButton.YesNo)
-                                .WithCaption("XIVLauncherCN")
+                                .WithCaption("XIVLauncherCN (Soil)")
                                 .WithParentWindow(_window)
                                 .Show();
                             if (dialog == MessageBoxResult.Yes)
@@ -1629,7 +1629,7 @@ namespace XIVLauncher.Windows.ViewModel
                     GamePath:{gamePath}
                     GameVersion:{Repository.Ffxiv.GetVer(gamePath)}
                     """,
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Asterisk);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Asterisk);
                 return false;
             }
 
@@ -1660,7 +1660,7 @@ namespace XIVLauncher.Windows.ViewModel
                 CustomMessageBox.Show(
                     Loc.Localize("DalamudVc2019RedistError",
                         "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage."),
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
             }
             catch (IDalamudCompatibilityCheck.ArchitectureNotSupportedException ex)
             {
@@ -1669,7 +1669,7 @@ namespace XIVLauncher.Windows.ViewModel
                 CustomMessageBox.Show(
                     Loc.Localize("DalamudArchError",
                         "Dalamud cannot run your computer's architecture. Please make sure that you are running a 64-bit version of Windows.\nIf you are using Windows on ARM, please make sure that x64-Emulation is enabled for XIVLauncher."),
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
             }
 
             try
@@ -1739,7 +1739,7 @@ namespace XIVLauncher.Windows.ViewModel
                 CustomMessageBox.Show(
                     Loc.Localize("DalamudVc2019RedistError",
                         "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage."),
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
             }
             catch (IDalamudCompatibilityCheck.ArchitectureNotSupportedException ex)
             {
@@ -1748,7 +1748,7 @@ namespace XIVLauncher.Windows.ViewModel
                 CustomMessageBox.Show(
                     Loc.Localize("DalamudArchError",
                         "Dalamud cannot run your computer's architecture. Please make sure that you are running a 64-bit version of Windows.\nIf you are using Windows on ARM, please make sure that x64-Emulation is enabled for XIVLauncher."),
-                    "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
+                    "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
             }
 
             if (App.Settings.InGameAddonEnabled && !forceNoDalamud)
@@ -1784,7 +1784,7 @@ namespace XIVLauncher.Windows.ViewModel
             stopwatch.Stop();
             if (stopwatch.Elapsed > TimeSpan.FromMinutes(5))
             {
-                CustomMessageBox.Show("会话已过期,请重新登录", "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
+                CustomMessageBox.Show("会话已过期,请重新登录", "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
                 return null;
             }
             // We won't do any sanity checks here anymore, since that should be handled in StartLogin
@@ -2004,7 +2004,7 @@ namespace XIVLauncher.Windows.ViewModel
 
             if (!mutex.WaitOne(0, false))
             {
-                CustomMessageBox.Show(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."), "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
+                CustomMessageBox.Show(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."), "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
                 Environment.Exit(0);
                 return false; // This line will not be run.
             }

--- a/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -137,7 +137,7 @@ namespace XIVLauncher.Windows.ViewModel
                 dynamic rateLimit = JObject.Parse(json);
                 if (!response.IsSuccessStatusCode)
                 {
-                    CustomMessageBox.Show($"获取 GitHub API 额度失败, 请检查你的 Token 是否正确\n{rateLimit.message}", "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    CustomMessageBox.Show($"获取 GitHub API 额度失败, 请检查你的 Token 是否正确\n{rateLimit.message}", "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Warning);
                     return;
                 }
 
@@ -147,11 +147,11 @@ namespace XIVLauncher.Windows.ViewModel
                 int resetTimestamp = rateLimit.resources.core.reset;
                 var resetTime = DateTimeOffset.FromUnixTimeSeconds(resetTimestamp).LocalDateTime;
                 var tokenOutput = string.IsNullOrWhiteSpace(_gitHubToken) ? "未设置 Token, 当前 IP " : "当前 Token ";
-                CustomMessageBox.Show($"{tokenOutput}的可用额度: {remaining}, 总额度: {limit}, 刷新时间: {resetTime:HH:mm:ss}", "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Information);
+                CustomMessageBox.Show($"{tokenOutput}的可用额度: {remaining}, 总额度: {limit}, 刷新时间: {resetTime:HH:mm:ss}", "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Information);
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("获取 GitHub API 额度失败\n" + ex.ToString(), "XIVLauncherCN", MessageBoxButton.OK, MessageBoxImage.Error);
+                CustomMessageBox.Show("获取 GitHub API 额度失败\n" + ex.ToString(), "XIVLauncherCN (Soil)", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 


### PR DESCRIPTION
抱歉忘记按feature开分支了，如果需要的话我自己拆出来
非重要修改，没有更改csproj文件

三个提交包括
1. 扫码登录的取消按钮由蓝色改为MD主题默认颜色（土月即橙色）
2. 账户管理器、及地球图标中硬编码的橙色改用MD提供的属性，不影响界面。未修改诸如警告、信息等含义图标的主题色使用
3. 将XIVLauncherCN修改为XIVLauncherCN (Soil)，仅影响软件弹出消息窗口的标题和首次启动创建的快捷方式名称，不改变实际功能

请问后续如果开发，是否考虑接受加入更改土月主题等功能