### PR TITLE
fix: 兼容需要回源的情况

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -76,6 +76,8 @@ public class DalamudUpdater
             ConnectCallback = HappyEyeballsCallback.ConnectCallback
         });
         this.httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
+        if (!string.IsNullOrWhiteSpace(this.githubToken)) 
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", this.githubToken);
     }
 
     public void Run(bool overrideForceProxy = false)

--- a/src/XIVLauncher/Support/XLHttpClientFileDownloader.cs
+++ b/src/XIVLauncher/Support/XLHttpClientFileDownloader.cs
@@ -147,6 +147,7 @@ public class XLHttpClientFileDownloader : IFileDownloader
     private HttpRequestMessage CreateRequest(HttpMethod method, string url, string authorization, string accept)
     {
         var request = new HttpRequestMessage(method, url);
+        request.Headers.UserAgent.ParseAdd("XIVLauncherCN");
 
         if (!string.IsNullOrWhiteSpace(accept))
         {


### PR DESCRIPTION
回源Github时，必须传入UserAgent 

https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required

反代还是需要解除海外用户的 302 逻辑，不然可能更新不了新版本