### PR TITLE
fix: 在写入完成后释放 stream 避免占用导致 File.Move 报错

### DIFF
--- a/src/XIVLauncher.Common/Patching/SdoFileDownload/SdoFileDownloadInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/SdoFileDownload/SdoFileDownloadInstaller.cs
@@ -169,18 +169,20 @@ public class SdoFileDownloadInstaller : IDisposable
 
                 try
                 {
-                    await using var source = await response.Content.ReadAsStreamAsync(ct);
-                    await using var sink = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, FILE_STREAM_BUFFER_SIZE, FileOptions.Asynchronous | FileOptions.SequentialScan);
-                    using var buffer = ReusableByteBufferManager.GetBuffer();
-
-                    while (true)
                     {
-                        var read = await source.ReadAsync(buffer.Buffer.AsMemory(0, buffer.Buffer.Length), ct);
-                        if (read == 0)
-                            break;
+                        await using var source = await response.Content.ReadAsStreamAsync(ct);
+                        await using var sink = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, FILE_STREAM_BUFFER_SIZE, FileOptions.Asynchronous | FileOptions.SequentialScan);
+                        using var buffer = ReusableByteBufferManager.GetBuffer();
 
-                        await sink.WriteAsync(buffer.Buffer.AsMemory(0, read), ct);
-                        ReportInstallProgress(targetIndex, Interlocked.Add(ref totalDownloadedBytes, read), Interlocked.Read(ref totalContentBytes), InstallTaskState.Downloading);
+                        while (true)
+                        {
+                            var read = await source.ReadAsync(buffer.Buffer.AsMemory(0, buffer.Buffer.Length), ct);
+                            if (read == 0)
+                                break;
+
+                            await sink.WriteAsync(buffer.Buffer.AsMemory(0, read), ct);
+                            ReportInstallProgress(targetIndex, Interlocked.Add(ref totalDownloadedBytes, read), Interlocked.Read(ref totalContentBytes), InstallTaskState.Downloading);
+                        }
                     }
 
                     File.Move(tempPath, targetFilePath, true);


### PR DESCRIPTION
```
2026-04-25 10:33:47.697 +08:00 [INF] LASTEXCEPTION:eyJXaGVuIjoiMjAyNi0wNC0yNVQxMDozMzo0Ny42OTcwMjE5KzA4OjAwIiwiSW5mbyI6IlN5c3RlbS5FeGNlcHRpb246IFN5c3RlbS5JTy5JT0V4Y2VwdGlvbjogVGhlIHByb2Nlc3MgY2Fubm90IGFjY2VzcyB0aGUgZmlsZSBiZWNhdXNlIGl0IGlzIGJlaW5nIHVzZWQgYnkgYW5vdGhlciBwcm9jZXNzLlxyXG4gICBhdCBTeXN0ZW0uSU8uRmlsZVN5c3RlbS5Nb3ZlRmlsZShTdHJpbmcgc291cmNlRnVsbFBhdGgsIFN0cmluZyBkZXN0RnVsbFBhdGgsIEJvb2xlYW4gb3ZlcndyaXRlKVxyXG4gICBhdCBYSVZMYXVuY2hlci5Db21tb24uUGF0Y2hpbmcuU2RvRmlsZURvd25sb2FkLlNkb0ZpbGVEb3dubG9hZEluc3RhbGxlci48PmNfX0Rpc3BsYXlDbGFzczE3XzAuPDxJbnN0YWxsPmJfXzA+ZC5Nb3ZlTmV4dCgpIGluIEM6XFxVc2Vyc1xcOTQ3MzdcXERvY3VtZW50c1xcQ1NoYXJwV29ya3NwYWNlXFxGRlhJVlF1aWNrTGF1bmNoZXJcXHNyY1xcWElWTGF1bmNoZXIuQ29tbW9uXFxQYXRjaGluZ1xcU2RvRmlsZURvd25sb2FkXFxTZG9GaWxlRG93bmxvYWRJbnN0YWxsZXIuY3M6bGluZSAxODZcclxuLS0tIEVuZCBvZiBzdGFjayB0cmFjZSBmcm9tIHByZXZpb3VzIGxvY2F0aW9uIC0tLVxyXG4gICBhdCBYSVZMYXVuY2hlci5Db21tb24uUGF0Y2hpbmcuU2RvRmlsZURvd25sb2FkLlNkb0ZpbGVEb3dubG9hZEluc3RhbGxlci48PmNfX0Rpc3BsYXlDbGFzczE3XzAuPDxJbnN0YWxsPmJfXzA+ZC5Nb3ZlTmV4dCgpIGluIEM6XFxVc2Vyc1xcOTQ3MzdcXERvY3VtZW50c1xcQ1NoYXJwV29ya3NwYWNlXFxGRlhJVlF1aWNrTGF1bmNoZXJcXHNyY1xcWElWTGF1bmNoZXIuQ29tbW9uXFxQYXRjaGluZ1xcU2RvRmlsZURvd25sb2FkXFxTZG9GaWxlRG93bmxvYWRJbnN0YWxsZXIuY3M6bGluZSAxODlcclxuLS0tIEVuZCBvZiBzdGFjayB0cmFjZSBmcm9tIHByZXZpb3VzIGxvY2F0aW9uIC0tLVxyXG4gICBhdCBYSVZMYXVuY2hlci5Db21tb24uUGF0Y2hpbmcuU2RvRmlsZURvd25sb2FkLlNkb0ZpbGVEb3dubG9hZEluc3RhbGxlci48PmNfX0Rpc3BsYXlDbGFzczE3XzAuPDxJbnN0YWxsPmJfXzA+ZC5Nb3ZlTmV4dCgpIGluIEM6XFxVc2Vyc1xcOTQ3MzdcXERvY3VtZW50c1xcQ1NoYXJwV29ya3NwYWNlXFxGRlhJVlF1aWNrTGF1bmNoZXJcXHNyY1xcWElWTGF1bmNoZXIuQ29tbW9uXFxQYXRjaGluZ1xcU2RvRmlsZURvd25sb2FkXFxTZG9GaWxlRG93bmxvYWRJbnN0YWxsZXIuY3M6bGluZSAxODlcclxuLS0tIEVuZCBvZiBzdGFjayB0cmFjZSBmcm9tIHByZXZpb3VzIGxvY2F0aW9uIC0tLVxyXG4gICBhdCBTeXN0ZW0uVGhyZWFkaW5nLlRhc2tzLlBhcmFsbGVsLjw+Y19fNTNgMS48PEZvckVhY2hBc3luYz5iX181M18wPmQuTW92ZU5leHQoKVxyXG4tLS0gRW5kIG9mIHN0YWNrIHRyYWNlIGZyb20gcHJldmlvdXMgbG9jYXRpb24gLS0tXHJcbiAgIGF0IFhJVkxhdW5jaGVyLkNvbW1vbi5QYXRjaGluZy5TZG9GaWxlRG93bmxvYWQuU2RvRmlsZURvd25sb2FkSW5zdGFsbGVyLkluc3RhbGwoU3RyaW5nIGdhbWVSb290UGF0aCwgSW50MzIgY29uY3VycmVudENvdW50LCBDYW5jZWxsYXRpb25Ub2tlbiBjYW5jZWxsYXRpb25Ub2tlbikgaW4gQzpcXFVzZXJzXFw5NDczN1xcRG9jdW1lbnRzXFxDU2hhcnBXb3Jrc3BhY2VcXEZGWElWUXVpY2tMYXVuY2hlclxcc3JjXFxYSVZMYXVuY2hlci5Db21tb25cXFBhdGNoaW5nXFxTZG9GaWxlRG93bmxvYWRcXFNkb0ZpbGVEb3dubG9hZEluc3RhbGxlci5jczpsaW5lIDE0NVxyXG4gICBhdCBYSVZMYXVuY2hlci5Db21tb24uUGF0Y2hpbmcuU2RvRmlsZURvd25sb2FkLlNkb0ZpbGVEb3dubG9hZFJlbW90ZUluc3RhbGxlci5Xb3JrZXJTdWJwcm9jZXNzQm9keS48LmN0b3I+Yl9fNl8wKFVJbnQ2NCBfLCBCeXRlW10gZGF0YSkgaW4gQzpcXFVzZXJzXFw5NDczN1xcRG9jdW1lbnRzXFxDU2hhcnBXb3Jrc3BhY2VcXEZGWElWUXVpY2tMYXVuY2hlclxcc3JjXFxYSVZMYXVuY2hlci5Db21tb25cXFBhdGNoaW5nXFxTZG9GaWxlRG93bmxvYWRcXFNkb0ZpbGVEb3dubG9hZFJlbW90ZUluc3RhbGxlci5jczpsaW5lIDQwOFxyXG4gICBhdCBYSVZMYXVuY2hlci5Db21tb24uUGF0Y2hpbmcuU2RvRmlsZURvd25sb2FkLlNkb0ZpbGVEb3dubG9hZFJlbW90ZUluc3RhbGxlci5XYWl0Rm9yUmVzdWx0KEJpbmFyeVdyaXRlciByZXEsIENhbmNlbGxhdGlvblRva2VuIGNhbmNlbGxhdGlvblRva2VuLCBJbnQzMiB0aW1lb3V0TXMsIEJvb2xlYW4gYXV0b0Rpc3Bvc2UpIGluIEM6XFxVc2Vyc1xcOTQ3MzdcXERvY3VtZW50c1xcQ1NoYXJwV29ya3NwYWNlXFxGRlhJVlF1aWNrTGF1bmNoZXJcXHNyY1xcWElWTGF1bmNoZXIuQ29tbW9uXFxQYXRjaGluZ1xcU2RvRmlsZURvd25sb2FkXFxTZG9GaWxlRG93bmxvYWRSZW1vdGVJbnN0YWxsZXIuY3M6bGluZSAyOTZcclxuICAgYXQgWElWTGF1bmNoZXIuQ29tbW9uLlBhdGNoaW5nLlNkb0ZpbGVEb3dubG9hZC5TZG9GaWxlRG93bmxvYWRSZW1vdGVJbnN0YWxsZXIuSW5zdGFsbChJbnQzMiBjb25jdXJyZW50Q291bnQsIENhbmNlbGxhdGlvblRva2VuIGNhbmNlbGxhdGlvblRva2VuKSBpbiBDOlxcVXNlcnNcXDk0NzM3XFxEb2N1bWVudHNcXENTaGFycFdvcmtzcGFjZVxcRkZYSVZRdWlja0xhdW5jaGVyXFxzcmNcXFhJVkxhdW5jaGVyLkNvbW1vblxcUGF0Y2hpbmdcXFNkb0ZpbGVEb3dubG9hZFxcU2RvRmlsZURvd25sb2FkUmVtb3RlSW5zdGFsbGVyLmNzOmxpbmUgMTI2XHJcbiAgIGF0IFhJVkxhdW5jaGVyLkNvbW1vbi5HYW1lLlBhdGNoLlBhdGNoVmVyaWZpZXIuUnVuVmVyaWZpZXIoKSBpbiBDOlxcVXNlcnNcXDk0NzM3XFxEb2N1bWVudHNcXENTaGFycFdvcmtzcGFjZVxcRkZYSVZRdWlja0xhdW5jaGVyXFxzcmNcXFhJVkxhdW5jaGVyLkNvbW1vblxcR2FtZVxcUGF0Y2hcXFBhdGNoVmVyaWZpZXIuY3M6bGluZSA0NDgiLCJDb250ZXh0IjoiVW5leHBlY3RlZCBlcnJvciBvY2N1cnJlZCBpbiBSdW5WZXJpZmllclYzIn0=
2026-04-25 10:33:47.695 +08:00 [ERR] Unexpected error occurred in RunVerifierV3
System.Exception: System.IO.IOException: The process cannot access the file because it is being used by another process.
   at System.IO.FileSystem.MoveFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadInstaller.<>c__DisplayClass17_0.<<Install>b__0>d.MoveNext() in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadInstaller.cs:line 186
--- End of stack trace from previous location ---
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadInstaller.<>c__DisplayClass17_0.<<Install>b__0>d.MoveNext() in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadInstaller.cs:line 189
--- End of stack trace from previous location ---
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadInstaller.<>c__DisplayClass17_0.<<Install>b__0>d.MoveNext() in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadInstaller.cs:line 189
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__53`1.<<ForEachAsync>b__53_0>d.MoveNext()
--- End of stack trace from previous location ---
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadInstaller.Install(String gameRootPath, Int32 concurrentCount, CancellationToken cancellationToken) in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadInstaller.cs:line 145
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadRemoteInstaller.WorkerSubprocessBody.<.ctor>b__6_0(UInt64 _, Byte[] data) in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadRemoteInstaller.cs:line 408
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadRemoteInstaller.WaitForResult(BinaryWriter req, CancellationToken cancellationToken, Int32 timeoutMs, Boolean autoDispose) in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadRemoteInstaller.cs:line 296
   at XIVLauncher.Common.Patching.SdoFileDownload.SdoFileDownloadRemoteInstaller.Install(Int32 concurrentCount, CancellationToken cancellationToken) in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Patching\SdoFileDownload\SdoFileDownloadRemoteInstaller.cs:line 126
   at XIVLauncher.Common.Game.Patch.PatchVerifier.RunVerifier() in C:\Users\94737\Documents\CSharpWorkspace\FFXIVQuickLauncher\src\XIVLauncher.Common\Game\Patch\PatchVerifier.cs:line 448
```