### PR TITLE
fix: 修复复杂网络环境下 Dalamud 更新易超时失败的问题并新增可配置更新策略

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdateHttpMode.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdateHttpMode.cs
@@ -1,0 +1,8 @@
+namespace XIVLauncher.Common.Dalamud;
+
+public enum DalamudUpdateHttpMode
+{
+    Auto = 0,
+    Http2 = 1,
+    Http11 = 2
+}

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -292,7 +292,7 @@ public class DalamudUpdater
 
     private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
     {
-        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(3), 50, DecompressionMethods.All, requestVersion, versionPolicy);
         client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
         if (!string.IsNullOrWhiteSpace(this.githubToken))
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
@@ -305,6 +305,7 @@ public class DalamudUpdater
         {
             switch (ex)
             {
+                case TimeoutException:
                 case TaskCanceledException or OperationCanceledException:
                 case HttpRequestException httpRequestException when httpRequestException.InnerException is TimeoutException:
                     return true;
@@ -616,15 +617,18 @@ public class DalamudUpdater
         }
         catch (HttpRequestException e)
         {
-            throw new Exception("访问 Github API 时发生错误: " + e.Message);
+            Log.Error(e, "[DUPDATE] 访问 Github API 时发生错误");
+            throw;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException e)
         {
-            throw new Exception("下载超时");
+            Log.Error(e, "[DUPDATE] 下载超时");
+            throw;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e)
         {
-            throw new Exception("下载取消");
+            Log.Error(e, "[DUPDATE] 下载取消");
+            throw;
         }
     }
 

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -63,6 +63,9 @@ public class DalamudUpdater
     private readonly DirectoryInfo assetDirectory;
     private readonly string?       githubToken;
     private readonly SemaphoreSlim runSemaphore = new(1, 1);
+    private readonly int updateTimeoutSeconds;
+    private readonly int updateMaxRetries;
+    private readonly DalamudUpdateHttpMode updateHttpMode;
 
     private HttpClient httpClient;
 
@@ -71,14 +74,24 @@ public class DalamudUpdater
         DirectoryInfo addonDirectory,
         DirectoryInfo runtimeDirectory,
         DirectoryInfo assetDirectory,
-        string?       githubToken
+        string?       githubToken,
+        int           updateTimeoutSeconds,
+        int           updateMaxRetries,
+        DalamudUpdateHttpMode updateHttpMode
     )
     {
         this.addonDirectory = addonDirectory;
         Runtime             = runtimeDirectory;
         this.assetDirectory = assetDirectory;
         this.githubToken    = githubToken;
-        httpClient = CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher);
+        this.updateTimeoutSeconds = Math.Clamp(updateTimeoutSeconds, 1, 30);
+        this.updateMaxRetries     = Math.Clamp(updateMaxRetries, 1, 10);
+        this.updateHttpMode       = updateHttpMode;
+        httpClient = this.updateHttpMode switch
+        {
+            DalamudUpdateHttpMode.Http11 => CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower),
+            _ => CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher)
+        };
     }
 
     public void Run() =>
@@ -101,14 +114,12 @@ public class DalamudUpdater
 
                 try
                 {
-                    const int MAX_TRIES = 3;
-
                     var isUpdated = false;
                     var hasTimeoutFailure = false;
                     var hasNonRetryableFailure = false;
                     Exception? lastException = null;
 
-                    for (var tries = 0; tries < MAX_TRIES; tries++)
+                    for (var tries = 0; tries < updateMaxRetries; tries++)
                     {
                         try
                         {
@@ -118,7 +129,7 @@ public class DalamudUpdater
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
                             EnsurementException = ex;
                             lastException = ex;
                             if (IsTimeoutException(ex))
@@ -128,14 +139,14 @@ public class DalamudUpdater
                         }
                     }
 
-                    if (!isUpdated && hasTimeoutFailure && !hasNonRetryableFailure)
+                    if (!isUpdated && updateHttpMode == DalamudUpdateHttpMode.Auto && hasTimeoutFailure && !hasNonRetryableFailure)
                     {
                         Log.Information("[DUPDATE] 检测到超时失败，降级至 HTTP/1.1 重试");
                         var previousClient = httpClient;
                         httpClient = CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
                         previousClient.Dispose();
 
-                        for (var tries = 0; tries < MAX_TRIES; tries++)
+                        for (var tries = 0; tries < updateMaxRetries; tries++)
                         {
                             try
                             {
@@ -145,7 +156,7 @@ public class DalamudUpdater
                             }
                             catch (Exception ex)
                             {
-                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
                                 EnsurementException = ex;
                                 lastException = ex;
                             }
@@ -292,7 +303,7 @@ public class DalamudUpdater
 
     private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
     {
-        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(3), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(updateTimeoutSeconds), 50, DecompressionMethods.All, requestVersion, versionPolicy);
         client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
         if (!string.IsNullOrWhiteSpace(this.githubToken))
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -5,8 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Serilog;
@@ -60,8 +62,9 @@ public class DalamudUpdater
     private readonly DirectoryInfo addonDirectory;
     private readonly DirectoryInfo assetDirectory;
     private readonly string?       githubToken;
+    private readonly SemaphoreSlim runSemaphore = new(1, 1);
 
-    private readonly HttpClient httpClient;
+    private HttpClient httpClient;
 
     public DalamudUpdater
     (
@@ -75,10 +78,7 @@ public class DalamudUpdater
         Runtime             = runtimeDirectory;
         this.assetDirectory = assetDirectory;
         this.githubToken    = githubToken;
-        httpClient          = XLHttpClientFactory.Create(TimeSpan.FromSeconds(10), 50, DecompressionMethods.All);
-        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
-        if (!string.IsNullOrWhiteSpace(this.githubToken))
-            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", this.githubToken);
+        httpClient = CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher);
     }
 
     public void Run() =>
@@ -97,26 +97,70 @@ public class DalamudUpdater
         Task.Run
         (async () =>
             {
-                const int MAX_TRIES = 10;
+                await runSemaphore.WaitAsync().ConfigureAwait(false);
 
-                var isUpdated = false;
-
-                for (var tries = 0; tries < MAX_TRIES; tries++)
+                try
                 {
-                    try
-                    {
-                        await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
-                        isUpdated = true;
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries, MAX_TRIES);
-                        EnsurementException = ex;
-                    }
-                }
+                    const int MAX_TRIES = 3;
 
-                State = isUpdated ? DownloadState.Done : DownloadState.NoIntegrity;
+                    var isUpdated = false;
+                    var hasTimeoutFailure = false;
+                    var hasNonRetryableFailure = false;
+                    Exception? lastException = null;
+
+                    for (var tries = 0; tries < MAX_TRIES; tries++)
+                    {
+                        try
+                        {
+                            await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
+                            isUpdated = true;
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                            EnsurementException = ex;
+                            lastException = ex;
+                            if (IsTimeoutException(ex))
+                                hasTimeoutFailure = true;
+                            if (IsNonRetryableException(ex))
+                                hasNonRetryableFailure = true;
+                        }
+                    }
+
+                    if (!isUpdated && hasTimeoutFailure && !hasNonRetryableFailure)
+                    {
+                        Log.Information("[DUPDATE] 检测到超时失败，降级至 HTTP/1.1 重试");
+                        var previousClient = httpClient;
+                        httpClient = CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
+                        previousClient.Dispose();
+
+                        for (var tries = 0; tries < MAX_TRIES; tries++)
+                        {
+                            try
+                            {
+                                await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
+                                isUpdated = true;
+                                break;
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                                EnsurementException = ex;
+                                lastException = ex;
+                            }
+                        }
+                    }
+
+                    if (!isUpdated && lastException != null)
+                        EnsurementException = lastException;
+
+                    State = isUpdated ? DownloadState.Done : DownloadState.NoIntegrity;
+                }
+                finally
+                {
+                    runSemaphore.Release();
+                }
             }
         );
     }
@@ -245,6 +289,58 @@ public class DalamudUpdater
     }
 
     #endregion
+
+    private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
+    {
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
+        if (!string.IsNullOrWhiteSpace(this.githubToken))
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
+        return client;
+    }
+
+    private static bool IsTimeoutException(Exception ex)
+    {
+        while (true)
+        {
+            switch (ex)
+            {
+                case TaskCanceledException or OperationCanceledException:
+                case HttpRequestException httpRequestException when httpRequestException.InnerException is TimeoutException:
+                    return true;
+            }
+
+            if (ex.InnerException != null)
+            {
+                ex = ex.InnerException;
+                continue;
+            }
+
+            return false;
+        }
+    }
+
+    private static bool IsNonRetryableException(Exception ex)
+    {
+        while (true)
+        {
+            switch (ex)
+            {
+                case DalamudIntegrityException or InvalidDataException:
+                case HttpRequestException httpRequestException
+                    when httpRequestException.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound:
+                    return true;
+            }
+
+            if (ex.InnerException != null)
+            {
+                ex = ex.InnerException;
+                continue;
+            }
+
+            return false;
+        }
+    }
 
     #region Dalamud
 

--- a/src/XIVLauncher.Common/Http/XLHttpClientFactory.cs
+++ b/src/XIVLauncher.Common/Http/XLHttpClientFactory.cs
@@ -10,7 +10,9 @@ public static class XLHttpClientFactory
     (
         TimeSpan             connectTimeout,
         int                  maxConnectionsPerServer,
-        DecompressionMethods automaticDecompression
+        DecompressionMethods automaticDecompression,
+        Version?             defaultRequestVersion = null,
+        HttpVersionPolicy    defaultVersionPolicy  = HttpVersionPolicy.RequestVersionOrHigher
     )
     {
         var client = new HttpClient
@@ -30,8 +32,8 @@ public static class XLHttpClientFactory
             }
         );
 
-        client.DefaultRequestVersion = HttpVersion.Version20;
-        client.DefaultVersionPolicy  = HttpVersionPolicy.RequestVersionOrHigher;
+        client.DefaultRequestVersion = defaultRequestVersion ?? HttpVersion.Version20;
+        client.DefaultVersionPolicy  = defaultVersionPolicy;
         return client;
     }
 }

--- a/src/XIVLauncher/Settings/LauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/LauncherSettingsV3.cs
@@ -183,6 +183,33 @@ public sealed class LauncherSettingsV3
         set => Set(ref field, value);
     } = 0;
 
+    /// <summary>
+    ///     Dalamud 更新连接超时（秒）
+    /// </summary>
+    public int DalamudUpdateTimeoutSeconds
+    {
+        get;
+        set => Set(ref field, value);
+    } = 3;
+
+    /// <summary>
+    ///     Dalamud 更新最大重试次数
+    /// </summary>
+    public int DalamudUpdateMaxRetries
+    {
+        get;
+        set => Set(ref field, value);
+    } = 3;
+
+    /// <summary>
+    ///     Dalamud 更新 HTTP 协议策略
+    /// </summary>
+    public DalamudUpdateHttpMode DalamudUpdateHttpMode
+    {
+        get;
+        set => Set(ref field, value);
+    } = DalamudUpdateHttpMode.Auto;
+
     #endregion
 
     #region 插件/扩展配置

--- a/src/XIVLauncher/Startup/StartupOrchestrator.cs
+++ b/src/XIVLauncher/Startup/StartupOrchestrator.cs
@@ -307,7 +307,10 @@ public class StartupOrchestrator
                 new(Path.Combine(Paths.RoamingPath, "addon")),
                 new(Path.Combine(Paths.RoamingPath, "runtime")),
                 new(Path.Combine(Paths.RoamingPath, "dalamudAssets")),
-                context.Settings.GitHubToken
+                context.Settings.GitHubToken,
+                context.Settings.DalamudUpdateTimeoutSeconds,
+                context.Settings.DalamudUpdateMaxRetries,
+                context.Settings.DalamudUpdateHttpMode
             );
 
             if (dalamudRunnerOverride != null)

--- a/src/XIVLauncher/Windows/SettingsWindow.xaml
+++ b/src/XIVLauncher/Windows/SettingsWindow.xaml
@@ -572,6 +572,88 @@
                                                  IsChecked="{Binding UseDllInjectLoadMethod}"
                                                  ToolTip="通过 DLL 注入方式加载 Dalamud, 兼容性取决于本机环境。"
                                                  Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" />
+                                 </StackPanel>
+                            </materialDesign:Card>
+
+                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="更新设置"
+                                       Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+                                       FontWeight="Medium"
+                                       Margin="0,24,0,16" />
+
+                            <materialDesign:Card Style="{StaticResource SettingCardStyle}">
+                                <StackPanel>
+                                    <Grid Margin="0,0,0,24">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新超时"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="控制 Dalamud 更新请求连接超时时间（1-30 秒）"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Right">
+                                            <TextBox Width="70" Text="{Binding DalamudUpdateTimeoutSeconds}"
+                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="秒"
+                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid Margin="0,0,0,24">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新重试次数"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="控制 Dalamud 更新失败后的重试次数（1-10 次）"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Right">
+                                            <TextBox Width="70" Text="{Binding DalamudUpdateMaxRetries}"
+                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="次"
+                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" MinWidth="180" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新协议"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="Auto: 先 HTTP/2，超时后回退 HTTP/1.1"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <ComboBox Grid.Column="1" SelectedIndex="{Binding DalamudUpdateHttpModeIndex}"
+                                                  VerticalAlignment="Center"
+                                                  Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
+                                            <ComboBoxItem Content="Auto" />
+                                            <ComboBoxItem Content="HTTP/2" />
+                                            <ComboBoxItem Content="HTTP/1.1" />
+                                        </ComboBox>
+                                    </Grid>
                                 </StackPanel>
                             </materialDesign:Card>
 

--- a/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
@@ -157,6 +157,24 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         }
     } = true;
 
+    public decimal? DalamudUpdateTimeoutSeconds
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
+    public decimal? DalamudUpdateMaxRetries
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
+    public int DalamudUpdateHttpModeIndex
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
     public string LaunchArgs
     {
         get;
@@ -318,6 +336,9 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         UseEntryPointLoadMethod                     = App.Settings.DalamudLoadMethod != DalamudLoadMethod.DllInject;
         EnableHooks                                 = App.Settings.DalamudEnabled;
         EnableDcTravel                              = true;
+        DalamudUpdateTimeoutSeconds                 = App.Settings.DalamudUpdateTimeoutSeconds;
+        DalamudUpdateMaxRetries                     = App.Settings.DalamudUpdateMaxRetries;
+        DalamudUpdateHttpModeIndex                  = (int)App.Settings.DalamudUpdateHttpMode;
         LaunchArgs                                  = App.Settings.AdditionalLaunchArgs ?? string.Empty;
         DpiAwarenessIndex                           = (int)App.Settings.DPIAwareness;
         VersionLabelText                            = $"XIVLauncher - v{AppUtil.GetAssemblyVersion()}";
@@ -350,6 +371,11 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         var addonEntries          = AddonEntries.ToList();
         var patchAcquisitionMethod = (AcquisitionMethod)PatchAcquisitionIndex;
         var dalamudLoadMethod      = UseDllInjectLoadMethod ? DalamudLoadMethod.DllInject : DalamudLoadMethod.EntryPoint;
+        var dalamudUpdateTimeoutSeconds = Math.Clamp((int)(DalamudUpdateTimeoutSeconds ?? 3), 1, 30);
+        var dalamudUpdateMaxRetries     = Math.Clamp((int)(DalamudUpdateMaxRetries     ?? 3), 1, 10);
+        var dalamudUpdateHttpMode       = Enum.IsDefined(typeof(DalamudUpdateHttpMode), DalamudUpdateHttpModeIndex)
+            ? (DalamudUpdateHttpMode)DalamudUpdateHttpModeIndex
+            : DalamudUpdateHttpMode.Auto;
         var dpiAwareness           = (DPIAwareness)DpiAwarenessIndex;
         var speedLimitBytes        = (long)((SpeedLimitMb ?? 0) * BYTES_TO_MB);
 
@@ -389,6 +415,9 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
                 settings.DalamudInjectionDelayMS             = DalamudInjectionDelayMs ?? 0;
                 settings.ManualInjectDelayMs                 = ManualInjectDelayMs     ?? 0;
                 settings.DalamudLoadMethod                   = dalamudLoadMethod;
+                settings.DalamudUpdateTimeoutSeconds         = dalamudUpdateTimeoutSeconds;
+                settings.DalamudUpdateMaxRetries             = dalamudUpdateMaxRetries;
+                settings.DalamudUpdateHttpMode               = dalamudUpdateHttpMode;
                 settings.AdditionalLaunchArgs                = LaunchArgs;
                 settings.DPIAwareness                        = dpiAwareness;
                 settings.SpeedLimitBytes                     = speedLimitBytes;
@@ -396,6 +425,10 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
                 settings.CredType                            = credTypeApplyResult.AppliedCredType;
             }
         );
+
+        DalamudUpdateTimeoutSeconds = dalamudUpdateTimeoutSeconds;
+        DalamudUpdateMaxRetries     = dalamudUpdateMaxRetries;
+        DalamudUpdateHttpModeIndex  = (int)dalamudUpdateHttpMode;
 
         SelectedCredType = credTypeApplyResult.AppliedCredType;
 


### PR DESCRIPTION
## 变更概述
在部分网络环境下（例如链路抖动、负载均衡、代理中间层），HTTP/2 请求可能发生超时，本 PR 主要解决 Dalamud 更新在复杂网络环境下的稳定性问题，并补充可配置的更新策略能力。

改动包含两部分：
1. 添加协议回退逻辑，默认 HTTP/2 连接如果多次超时后会回退到 HTTP/1.1 再次重试，对应 Auto 模式。
2. 在设置界面新增 Dalamud 更新策略配置项，支持显式定义超时、重试次数与协议模式，设置可持久化。

对于复杂网络，设置到 HTTP/1.1 可以解决大部分超时问题。

## 主要改动

### 更新链路修改
- 收紧默认连接超时与重试策略，降低长时间无效等待
- 增加 HTTP/2 失败后的 HTTP/1.1 重试回退路径以提升复杂网络兼容性
- 引入更新执行并发保护，避免重复触发导致状态竞争

### UI 增加更新策略配置
- 新增可持久化配置项：
  - 更新超时秒数
  - 最大重试次数
  - 更新协议模式（Auto / HTTP/2 / HTTP/1.1）
- 设置页 Dalamud 分组新增“更新设置”区块，支持直接配置上述参数
- 协议模式行为：
  - `Auto`：HTTP/2 超时后回退 HTTP/1.1
  - `HTTP/2`：固定 HTTP/2，不回退
  - `HTTP/1.1`：固定 HTTP/1.1，不回退
- 对输入做边界约束：
  - 超时：1-30 秒
  - 重试：1-10 次