### PR TITLE
fix: 修复复杂网络环境下 Dalamud 更新易超时失败的问题

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/AssetManager.cs
+++ b/src/XIVLauncher.Common/Dalamud/AssetManager.cs
@@ -17,7 +17,7 @@ namespace XIVLauncher.Common.Dalamud;
 
 public class AssetManager
 {
-    public static async Task<(DirectoryInfo AssetDir, int Version)> EnsureAssets(DalamudUpdater updater, DirectoryInfo baseDir)
+    internal static async Task<(DirectoryInfo AssetDir, int Version)> EnsureAssets(DalamudUpdater updater, DirectoryInfo baseDir, DalamudUpdater.HttpProtocol protocol, DalamudUpdater.UpdateSessionContext session)
     {
         using var metaClient = XLHttpClientFactory.Create
         (
@@ -82,7 +82,7 @@ public class AssetManager
             }
         }
 
-        var tasks = new List<Task<bool>>();
+        var tasks = new List<Task>(assetFileDownloadList.Count);
 
         foreach (var entry in assetFileDownloadList)
         {
@@ -117,10 +117,8 @@ public class AssetManager
 
         if (tasks.Count > 0)
         {
-            var downloadResults = await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            for (var i = 0; i < downloadResults.Length; i++)
-                isRefreshNeeded |= downloadResults[i];
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            isRefreshNeeded = true;
         }
 
         if (isRefreshNeeded)
@@ -151,18 +149,17 @@ public class AssetManager
 
         return (currentDir, info.Version);
 
-        async Task<bool> Download(string url, string path)
+        async Task Download(string url, string path)
         {
             try
             {
                 Log.Information("[DASSET] 正在下载 {0} 至 {1}...", url, path);
-                await updater.DownloadFile(url, path).ConfigureAwait(false);
-                return true;
+                await updater.DownloadFile(url, path, protocol, session).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "[DASSET] 无法下载资源文件: {0}", url);
-                return false;
+                throw;
             }
         }
     }

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdateHttpMode.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdateHttpMode.cs
@@ -1,0 +1,8 @@
+namespace XIVLauncher.Common.Dalamud;
+
+public enum DalamudUpdateHttpMode
+{
+    Auto = 0,
+    Http2 = 1,
+    Http11 = 2
+}

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -292,7 +292,7 @@ public class DalamudUpdater
 
     private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
     {
-        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(3), 50, DecompressionMethods.All, requestVersion, versionPolicy);
         client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
         if (!string.IsNullOrWhiteSpace(this.githubToken))
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
@@ -305,6 +305,7 @@ public class DalamudUpdater
         {
             switch (ex)
             {
+                case TimeoutException:
                 case TaskCanceledException or OperationCanceledException:
                 case HttpRequestException httpRequestException when httpRequestException.InnerException is TimeoutException:
                     return true;
@@ -616,15 +617,18 @@ public class DalamudUpdater
         }
         catch (HttpRequestException e)
         {
-            throw new Exception("访问 Github API 时发生错误: " + e.Message);
+            Log.Error(e, "[DUPDATE] 访问 Github API 时发生错误");
+            throw;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException e)
         {
-            throw new Exception("下载超时");
+            Log.Error(e, "[DUPDATE] 下载超时");
+            throw;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e)
         {
-            throw new Exception("下载取消");
+            Log.Error(e, "[DUPDATE] 下载取消");
+            throw;
         }
     }
 

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -63,6 +63,9 @@ public class DalamudUpdater
     private readonly DirectoryInfo assetDirectory;
     private readonly string?       githubToken;
     private readonly SemaphoreSlim runSemaphore = new(1, 1);
+    private readonly int updateTimeoutSeconds;
+    private readonly int updateMaxRetries;
+    private readonly DalamudUpdateHttpMode updateHttpMode;
 
     private HttpClient httpClient;
 
@@ -71,14 +74,24 @@ public class DalamudUpdater
         DirectoryInfo addonDirectory,
         DirectoryInfo runtimeDirectory,
         DirectoryInfo assetDirectory,
-        string?       githubToken
+        string?       githubToken,
+        int           updateTimeoutSeconds,
+        int           updateMaxRetries,
+        DalamudUpdateHttpMode updateHttpMode
     )
     {
         this.addonDirectory = addonDirectory;
         Runtime             = runtimeDirectory;
         this.assetDirectory = assetDirectory;
         this.githubToken    = githubToken;
-        httpClient = CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher);
+        this.updateTimeoutSeconds = Math.Clamp(updateTimeoutSeconds, 1, 30);
+        this.updateMaxRetries     = Math.Clamp(updateMaxRetries, 1, 10);
+        this.updateHttpMode       = updateHttpMode;
+        httpClient = this.updateHttpMode switch
+        {
+            DalamudUpdateHttpMode.Http11 => CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower),
+            _ => CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher)
+        };
     }
 
     public void Run() =>
@@ -101,14 +114,12 @@ public class DalamudUpdater
 
                 try
                 {
-                    const int MAX_TRIES = 3;
-
                     var isUpdated = false;
                     var hasTimeoutFailure = false;
                     var hasNonRetryableFailure = false;
                     Exception? lastException = null;
 
-                    for (var tries = 0; tries < MAX_TRIES; tries++)
+                    for (var tries = 0; tries < updateMaxRetries; tries++)
                     {
                         try
                         {
@@ -118,7 +129,7 @@ public class DalamudUpdater
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
                             EnsurementException = ex;
                             lastException = ex;
                             if (IsTimeoutException(ex))
@@ -128,14 +139,14 @@ public class DalamudUpdater
                         }
                     }
 
-                    if (!isUpdated && hasTimeoutFailure && !hasNonRetryableFailure)
+                    if (!isUpdated && updateHttpMode == DalamudUpdateHttpMode.Auto && hasTimeoutFailure && !hasNonRetryableFailure)
                     {
                         Log.Information("[DUPDATE] 检测到超时失败，降级至 HTTP/1.1 重试");
                         var previousClient = httpClient;
                         httpClient = CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
                         previousClient.Dispose();
 
-                        for (var tries = 0; tries < MAX_TRIES; tries++)
+                        for (var tries = 0; tries < updateMaxRetries; tries++)
                         {
                             try
                             {
@@ -145,7 +156,7 @@ public class DalamudUpdater
                             }
                             catch (Exception ex)
                             {
-                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
                                 EnsurementException = ex;
                                 lastException = ex;
                             }
@@ -292,7 +303,7 @@ public class DalamudUpdater
 
     private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
     {
-        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(3), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(updateTimeoutSeconds), 50, DecompressionMethods.All, requestVersion, versionPolicy);
         client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
         if (!string.IsNullOrWhiteSpace(this.githubToken))
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -5,8 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Serilog;
@@ -60,8 +62,9 @@ public class DalamudUpdater
     private readonly DirectoryInfo addonDirectory;
     private readonly DirectoryInfo assetDirectory;
     private readonly string?       githubToken;
+    private readonly SemaphoreSlim runSemaphore = new(1, 1);
 
-    private readonly HttpClient httpClient;
+    private HttpClient httpClient;
 
     public DalamudUpdater
     (
@@ -75,10 +78,7 @@ public class DalamudUpdater
         Runtime             = runtimeDirectory;
         this.assetDirectory = assetDirectory;
         this.githubToken    = githubToken;
-        httpClient          = XLHttpClientFactory.Create(TimeSpan.FromSeconds(10), 50, DecompressionMethods.All);
-        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
-        if (!string.IsNullOrWhiteSpace(this.githubToken))
-            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", this.githubToken);
+        httpClient = CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher);
     }
 
     public void Run() =>
@@ -97,26 +97,70 @@ public class DalamudUpdater
         Task.Run
         (async () =>
             {
-                const int MAX_TRIES = 10;
+                await runSemaphore.WaitAsync().ConfigureAwait(false);
 
-                var isUpdated = false;
-
-                for (var tries = 0; tries < MAX_TRIES; tries++)
+                try
                 {
-                    try
-                    {
-                        await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
-                        isUpdated = true;
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries, MAX_TRIES);
-                        EnsurementException = ex;
-                    }
-                }
+                    const int MAX_TRIES = 3;
 
-                State = isUpdated ? DownloadState.Done : DownloadState.NoIntegrity;
+                    var isUpdated = false;
+                    var hasTimeoutFailure = false;
+                    var hasNonRetryableFailure = false;
+                    Exception? lastException = null;
+
+                    for (var tries = 0; tries < MAX_TRIES; tries++)
+                    {
+                        try
+                        {
+                            await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
+                            isUpdated = true;
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                            EnsurementException = ex;
+                            lastException = ex;
+                            if (IsTimeoutException(ex))
+                                hasTimeoutFailure = true;
+                            if (IsNonRetryableException(ex))
+                                hasNonRetryableFailure = true;
+                        }
+                    }
+
+                    if (!isUpdated && hasTimeoutFailure && !hasNonRetryableFailure)
+                    {
+                        Log.Information("[DUPDATE] 检测到超时失败，降级至 HTTP/1.1 重试");
+                        var previousClient = httpClient;
+                        httpClient = CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
+                        previousClient.Dispose();
+
+                        for (var tries = 0; tries < MAX_TRIES; tries++)
+                        {
+                            try
+                            {
+                                await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
+                                isUpdated = true;
+                                break;
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, MAX_TRIES);
+                                EnsurementException = ex;
+                                lastException = ex;
+                            }
+                        }
+                    }
+
+                    if (!isUpdated && lastException != null)
+                        EnsurementException = lastException;
+
+                    State = isUpdated ? DownloadState.Done : DownloadState.NoIntegrity;
+                }
+                finally
+                {
+                    runSemaphore.Release();
+                }
             }
         );
     }
@@ -245,6 +289,58 @@ public class DalamudUpdater
     }
 
     #endregion
+
+    private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
+    {
+        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
+        if (!string.IsNullOrWhiteSpace(this.githubToken))
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
+        return client;
+    }
+
+    private static bool IsTimeoutException(Exception ex)
+    {
+        while (true)
+        {
+            switch (ex)
+            {
+                case TaskCanceledException or OperationCanceledException:
+                case HttpRequestException httpRequestException when httpRequestException.InnerException is TimeoutException:
+                    return true;
+            }
+
+            if (ex.InnerException != null)
+            {
+                ex = ex.InnerException;
+                continue;
+            }
+
+            return false;
+        }
+    }
+
+    private static bool IsNonRetryableException(Exception ex)
+    {
+        while (true)
+        {
+            switch (ex)
+            {
+                case DalamudIntegrityException or InvalidDataException:
+                case HttpRequestException httpRequestException
+                    when httpRequestException.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound:
+                    return true;
+            }
+
+            if (ex.InnerException != null)
+            {
+                ex = ex.InnerException;
+                continue;
+            }
+
+            return false;
+        }
+    }
 
     #region Dalamud
 

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,15 +60,19 @@ public class DalamudUpdater
     private static readonly ConcurrentDictionary<string, (long Length, long LastWriteTimeUtcTicks, string Hash)> CachedFileHashes =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private static readonly JsonSerializerOptions StateJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static readonly UTF8Encoding Utf8WithoutBom = new(false);
+
     private readonly DirectoryInfo addonDirectory;
     private readonly DirectoryInfo assetDirectory;
     private readonly string?       githubToken;
     private readonly SemaphoreSlim runSemaphore = new(1, 1);
-    private readonly int updateTimeoutSeconds;
-    private readonly int updateMaxRetries;
     private readonly DalamudUpdateHttpMode updateHttpMode;
-
-    private HttpClient httpClient;
+    private readonly FileInfo protocolStateFile = new(Path.Combine(Paths.RoamingPath, "dalamudUpdateState.json"));
 
     public DalamudUpdater
     (
@@ -75,8 +80,6 @@ public class DalamudUpdater
         DirectoryInfo runtimeDirectory,
         DirectoryInfo assetDirectory,
         string?       githubToken,
-        int           updateTimeoutSeconds,
-        int           updateMaxRetries,
         DalamudUpdateHttpMode updateHttpMode
     )
     {
@@ -84,14 +87,7 @@ public class DalamudUpdater
         Runtime             = runtimeDirectory;
         this.assetDirectory = assetDirectory;
         this.githubToken    = githubToken;
-        this.updateTimeoutSeconds = Math.Clamp(updateTimeoutSeconds, 1, 30);
-        this.updateMaxRetries     = Math.Clamp(updateMaxRetries, 1, 10);
-        this.updateHttpMode       = updateHttpMode;
-        httpClient = this.updateHttpMode switch
-        {
-            DalamudUpdateHttpMode.Http11 => CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower),
-            _ => CreateHttpClient(HttpVersion.Version20, HttpVersionPolicy.RequestVersionOrHigher)
-        };
+        this.updateHttpMode = updateHttpMode;
     }
 
     public void Run() =>
@@ -107,87 +103,35 @@ public class DalamudUpdater
         LoadingProgress     = null;
         State               = DownloadState.Unknown;
 
-        Task.Run
-        (async () =>
+        Task.Run(async () =>
+        {
+            await runSemaphore.WaitAsync().ConfigureAwait(false);
+
+            try
             {
-                await runSemaphore.WaitAsync().ConfigureAwait(false);
-
-                try
-                {
-                    var isUpdated = false;
-                    var hasTimeoutFailure = false;
-                    var hasNonRetryableFailure = false;
-                    Exception? lastException = null;
-
-                    for (var tries = 0; tries < updateMaxRetries; tries++)
-                    {
-                        try
-                        {
-                            await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
-                            isUpdated = true;
-                            break;
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error(ex, "[DUPDATE] 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
-                            EnsurementException = ex;
-                            lastException = ex;
-                            if (IsTimeoutException(ex))
-                                hasTimeoutFailure = true;
-                            if (IsNonRetryableException(ex))
-                                hasNonRetryableFailure = true;
-                        }
-                    }
-
-                    if (!isUpdated && updateHttpMode == DalamudUpdateHttpMode.Auto && hasTimeoutFailure && !hasNonRetryableFailure)
-                    {
-                        Log.Information("[DUPDATE] 检测到超时失败，降级至 HTTP/1.1 重试");
-                        var previousClient = httpClient;
-                        httpClient = CreateHttpClient(HttpVersion.Version11, HttpVersionPolicy.RequestVersionOrLower);
-                        previousClient.Dispose();
-
-                        for (var tries = 0; tries < updateMaxRetries; tries++)
-                        {
-                            try
-                            {
-                                await UpdateDalamud(refreshVersionInfo).ConfigureAwait(true);
-                                isUpdated = true;
-                                break;
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex, "[DUPDATE] HTTP/1.1 更新失败, 重试 {TryCnt}/{MaxTries}...", tries + 1, updateMaxRetries);
-                                EnsurementException = ex;
-                                lastException = ex;
-                            }
-                        }
-                    }
-
-                    if (!isUpdated && lastException != null)
-                        EnsurementException = lastException;
-
-                    State = isUpdated ? DownloadState.Done : DownloadState.NoIntegrity;
-                }
-                finally
-                {
-                    runSemaphore.Release();
-                }
+                var result = await RunWithAdaptiveStrategyAsync(refreshVersionInfo).ConfigureAwait(false);
+                EnsurementException = result.LastException;
+                State               = result.IsSuccess ? DownloadState.Done : DownloadState.NoIntegrity;
             }
-        );
+            finally
+            {
+                runSemaphore.Release();
+            }
+        });
     }
 
     #region Steps
 
-    private async Task UpdateDalamud(bool refreshVersionInfo)
+    private async Task UpdateDalamud(bool refreshVersionInfo, UpdateSessionContext session, HttpClient httpClient)
     {
         try
         {
-            Log.Information("[DUPDATE] 开始 Dalamud 更新进程");
+            Log.Information("[DUPDATE] 开始 Dalamud 更新进程 attempt={Attempt} protocol={Protocol}", session.Attempt, session.Protocol);
 
-            await InitVersionInfoAsync(refreshVersionInfo);
+            await InitVersionInfoAsync(refreshVersionInfo, httpClient);
             var paths                  = PreparePaths();
-            var currentVersionVerified = await UpdateDalamudCoreAsync(paths.addonPath, paths.currentVersionPath);
-            await UpdateRuntimeAsync();
+            var currentVersionVerified = await UpdateDalamudCoreAsync(paths.addonPath, paths.currentVersionPath, session, httpClient);
+            await UpdateRuntimeAsync(httpClient);
             await UpdateAssetsAsync();
 
             if (!currentVersionVerified && !CheckDalamudIntegrity(paths.currentVersionPath))
@@ -206,7 +150,7 @@ public class DalamudUpdater
         }
     }
 
-    private async Task InitVersionInfoAsync(bool refreshVersionInfo)
+    private async Task InitVersionInfoAsync(bool refreshVersionInfo, HttpClient httpClient)
     {
         Log.Verbose("[DUPDATE] 开始检查版本信息");
 
@@ -217,7 +161,7 @@ public class DalamudUpdater
         }
 
         Log.Information("[DUPDATE] 正在从 Github 获取最新版本信息");
-        await GetDalamudVersionInfoAsync();
+        await GetDalamudVersionInfoAsync(httpClient);
         Log.Information("[DUPDATE] 获取到版本: {Version} ({Hash})", Version, OnlineHash);
     }
 
@@ -228,16 +172,11 @@ public class DalamudUpdater
         var addonPath          = new DirectoryInfo(Path.Combine(addonDirectory.FullName, "Hooks"));
         var currentVersionPath = new DirectoryInfo(Path.Combine(addonPath.FullName,      Version));
 
-        Log.Verbose
-        (
-            "[DUPDATE] 路径信息: 版本路径={Path}",
-            currentVersionPath.FullName
-        );
-
+        Log.Verbose("[DUPDATE] 路径信息: 版本路径={Path}", currentVersionPath.FullName);
         return (addonPath, currentVersionPath);
     }
 
-    private async Task<bool> UpdateDalamudCoreAsync(DirectoryInfo addonPath, DirectoryInfo currentVersionPath)
+    private async Task<bool> UpdateDalamudCoreAsync(DirectoryInfo addonPath, DirectoryInfo currentVersionPath, UpdateSessionContext session, HttpClient metadataHttpClient)
     {
         Log.Information("[DUPDATE] 开始检查 Dalamud 本体完整性");
 
@@ -253,7 +192,7 @@ public class DalamudUpdater
         try
         {
             Log.Information("[DUPDATE] 开始下载 Dalamud 本体");
-            await DownloadDalamud(currentVersionPath).ConfigureAwait(true);
+            await DownloadDalamud(currentVersionPath, metadataHttpClient, session).ConfigureAwait(true);
 
             Log.Information("[DUPDATE] 清理旧版本 Dalamud 文件");
             CleanUpOld(addonPath, Version);
@@ -268,7 +207,7 @@ public class DalamudUpdater
         }
     }
 
-    private async Task UpdateRuntimeAsync() =>
+    private async Task UpdateRuntimeAsync(HttpClient httpClient) =>
         await DotNetRuntimeManager.EnsureRuntimeAsync
         (
             Runtime,
@@ -276,7 +215,8 @@ public class DalamudUpdater
             "win-x64",
             ".NET 运行时",
             SetLoadingDetail,
-            ReportLoadingProgressCore
+            ReportLoadingProgressCore,
+            cancellationToken: default
         ).ConfigureAwait(false);
 
     private async Task UpdateAssetsAsync()
@@ -301,59 +241,6 @@ public class DalamudUpdater
 
     #endregion
 
-    private HttpClient CreateHttpClient(Version requestVersion, HttpVersionPolicy versionPolicy)
-    {
-        var client = XLHttpClientFactory.Create(TimeSpan.FromSeconds(updateTimeoutSeconds), 50, DecompressionMethods.All, requestVersion, versionPolicy);
-        client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
-        if (!string.IsNullOrWhiteSpace(this.githubToken))
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
-        return client;
-    }
-
-    private static bool IsTimeoutException(Exception ex)
-    {
-        while (true)
-        {
-            switch (ex)
-            {
-                case TimeoutException:
-                case TaskCanceledException or OperationCanceledException:
-                case HttpRequestException httpRequestException when httpRequestException.InnerException is TimeoutException:
-                    return true;
-            }
-
-            if (ex.InnerException != null)
-            {
-                ex = ex.InnerException;
-                continue;
-            }
-
-            return false;
-        }
-    }
-
-    private static bool IsNonRetryableException(Exception ex)
-    {
-        while (true)
-        {
-            switch (ex)
-            {
-                case DalamudIntegrityException or InvalidDataException:
-                case HttpRequestException httpRequestException
-                    when httpRequestException.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound:
-                    return true;
-            }
-
-            if (ex.InnerException != null)
-            {
-                ex = ex.InnerException;
-                continue;
-            }
-
-            return false;
-        }
-    }
-
     #region Dalamud
 
     private async Task<bool> TryUpdateDalamudIncrementally
@@ -361,7 +248,9 @@ public class DalamudUpdater
         DirectoryInfo              addonPath,
         DirectoryInfo              devPath,
         Dictionary<string, string> assets,
-        string                     manifestUrl
+        string                     manifestUrl,
+        HttpClient                 httpClient,
+        UpdateSessionContext       session
     )
     {
         var       manifestJson = await httpClient.GetStringAsync(manifestUrl).ConfigureAwait(false);
@@ -383,7 +272,8 @@ public class DalamudUpdater
         }
 
         plan.DownloadFiles.Add((hashesUrl, GetReleaseFilePath(addonPath, manifest.HashesAsset), OnlineHash));
-        await DownloadVerifiedFiles(plan.DownloadFiles).ConfigureAwait(false);
+        using var downloadHttpClient = CreateDalamudDownloadHttpClient(session.Protocol);
+        await DownloadVerifiedFiles(plan.DownloadFiles, downloadHttpClient, session).ConfigureAwait(false);
         CleanDalamudReleaseDirectory(addonPath, plan.KeepPaths);
 
         Log.Information
@@ -579,7 +469,7 @@ public class DalamudUpdater
         }
     }
 
-    public async Task GetDalamudVersionInfoAsync()
+    public async Task GetDalamudVersionInfoAsync(HttpClient httpClient)
     {
         try
         {
@@ -590,8 +480,8 @@ public class DalamudUpdater
             var response = await httpClient.GetAsync(Links.DALAMUD_RELEASE_INFO_URL);
             await response.EnsureSuccessWithDiagnosticsAsync().ConfigureAwait(false);
 
-            var       json    = await response.Content.ReadAsStringAsync();
-            using var jsonDoc = JsonDocument.Parse(json);
+            var    json    = await response.Content.ReadAsStringAsync();
+            using var jsonDoc = JsonDocument.Parse(json ?? string.Empty);
 
             var version = jsonDoc.RootElement.GetProperty("tag_name").GetString();
             if (string.IsNullOrWhiteSpace(version))
@@ -611,8 +501,8 @@ public class DalamudUpdater
                 using (var fileResponse = await httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                 {
                     await fileResponse.EnsureSuccessWithDiagnosticsAsync().ConfigureAwait(false);
-                    using (var fileStream = new FileStream(downloadPath, FileMode.Create, FileAccess.Write, FileShare.None))
-                        await fileResponse.Content.CopyToAsync(fileStream);
+                    using var fileStream = new FileStream(downloadPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                    await fileResponse.Content.CopyToAsync(fileStream);
                 }
 
                 var hash = ComputeFileHash(downloadPath);
@@ -643,11 +533,11 @@ public class DalamudUpdater
         }
     }
 
-    private async Task DownloadDalamud(DirectoryInfo addonPath)
+    private async Task DownloadDalamud(DirectoryInfo addonPath, HttpClient metadataHttpClient, UpdateSessionContext session)
     {
         try
         {
-            var response = await httpClient.GetAsync(Links.DALAMUD_RELEASE_INFO_URL);
+            var response = await metadataHttpClient.GetAsync(Links.DALAMUD_RELEASE_INFO_URL);
             await response.EnsureSuccessWithDiagnosticsAsync().ConfigureAwait(false);
 
             var       json         = await response.Content.ReadAsStringAsync();
@@ -663,15 +553,15 @@ public class DalamudUpdater
             {
                 Log.Information("[DUPDATE] 发现 Dalamud 文件清单, 开始按需更新");
 
-                var incrementalUpdated = await TryUpdateDalamudIncrementally(addonPath, devPath, assets, manifestUrl).ConfigureAwait(false);
+                var incrementalUpdated = await TryUpdateDalamudIncrementally(addonPath, devPath, assets, manifestUrl, metadataHttpClient, session).ConfigureAwait(false);
 
                 if (!incrementalUpdated)
-                    await DownloadDalamudPackage(addonPath, assets).ConfigureAwait(false);
+                    await DownloadDalamudPackage(addonPath, assets, session).ConfigureAwait(false);
             }
             else
             {
                 Log.Information(hasLocalSeed ? "[DUPDATE] 未发现 Dalamud 文件清单, 开始下载完整包" : "[DUPDATE] 未发现可复用 Dalamud 本地基线, 开始下载完整包");
-                await DownloadDalamudPackage(addonPath, assets).ConfigureAwait(false);
+                await DownloadDalamudPackage(addonPath, assets, session).ConfigureAwait(false);
             }
 
             CachedFileHashes.Clear();
@@ -693,7 +583,7 @@ public class DalamudUpdater
 
     #region Utility
 
-    private async Task DownloadDalamudPackage(DirectoryInfo addonPath, Dictionary<string, string> assets)
+    private async Task DownloadDalamudPackage(DirectoryInfo addonPath, Dictionary<string, string> assets, UpdateSessionContext session)
     {
         if (!assets.TryGetValue(RELEASE_PACKAGE_ASSET, out var downloadUrl))
             throw new InvalidDataException("[DUPDATE] 未找到 Dalamud 完整包");
@@ -705,7 +595,8 @@ public class DalamudUpdater
 
         try
         {
-            await DownloadFiles([(downloadUrl, downloadPath)]).ConfigureAwait(false);
+            using var downloadHttpClient = CreateDalamudDownloadHttpClient(session.Protocol);
+            await DownloadFiles([(downloadUrl, downloadPath)], downloadHttpClient, session).ConfigureAwait(false);
             PlatformHelpers.Unzip7ZAsset(downloadPath, addonPath.FullName);
         }
         finally
@@ -715,7 +606,7 @@ public class DalamudUpdater
         }
     }
 
-    private async Task DownloadVerifiedFiles(IReadOnlyList<(string Url, string Path, string Hash)> files)
+    private async Task DownloadVerifiedFiles(IReadOnlyList<(string Url, string Path, string Hash)> files, HttpClient httpClient, UpdateSessionContext session)
     {
         if (files.Count == 0)
             return;
@@ -730,7 +621,7 @@ public class DalamudUpdater
 
         try
         {
-            await DownloadFiles(downloads).ConfigureAwait(false);
+            await DownloadFiles(downloads, httpClient, session).ConfigureAwait(false);
 
             for (var i = 0; i < files.Count; i++)
             {
@@ -757,6 +648,21 @@ public class DalamudUpdater
                     File.Delete(download.Path);
             }
         }
+    }
+
+    private async Task DownloadFiles(IReadOnlyList<(string Url, string Path)> files, HttpClient httpClient, UpdateSessionContext session)
+    {
+        using var downloader = new HttpClientDownloadWithProgress(files, httpClient, NoProgressTimeout);
+        downloader.ProgressChanged += (size, downloaded, progress) =>
+        {
+            var hadProgress = downloaded > session.LastDownloadedBytes;
+            session.LastAttemptHadProgress = session.LastAttemptHadProgress || hadProgress;
+            session.LastDownloadedBytes    = downloaded;
+            session.LastNoProgressDuration = hadProgress ? TimeSpan.Zero : NoProgressTimeout;
+            ReportLoadingProgressCore(size, downloaded, progress);
+        };
+
+        await downloader.Download().ConfigureAwait(false);
     }
 
     private static Dictionary<string, string> GetReleaseAssetUrls(JsonElement assets)
@@ -908,15 +814,12 @@ public class DalamudUpdater
         }
     }
 
-    public async Task DownloadFile(string url, string path) =>
-        await DownloadFiles([(url, path)]).ConfigureAwait(false);
-
-    private async Task DownloadFiles(IReadOnlyList<(string Url, string Path)> files)
+    public async Task DownloadFile(string url, string path)
     {
-        using var downloader = new HttpClientDownloadWithProgress(files);
-        downloader.ProgressChanged += ReportLoadingProgressCore;
-
-        await downloader.Download().ConfigureAwait(false);
+        using var httpClient = CreateHttpClient(ResolveInitialProtocol());
+        httpClient.Timeout = DalamudDownloadTimeout;
+        var session = new UpdateSessionContext { Protocol = ResolveInitialProtocol() };
+        await DownloadFiles([(url, path)], httpClient, session).ConfigureAwait(false);
     }
 
     #endregion
@@ -950,6 +853,282 @@ public class DalamudUpdater
 
     #endregion
 
+    #region Strategy
+
+    private async Task<UpdateExecutionResult> RunWithAdaptiveStrategyAsync(bool refreshVersionInfo)
+    {
+        var session = new UpdateSessionContext
+        {
+            StartedAtUtc = DateTime.UtcNow,
+            Protocol     = ResolveInitialProtocol(),
+            UpdateMode   = updateHttpMode
+        };
+
+        Exception? lastException = null;
+        var fallbackTriggered = false;
+
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            var previousAttemptHadProgress = session.LastAttemptHadProgress;
+            session.Attempt            = attempt;
+            session.Elapsed            = DateTime.UtcNow - session.StartedAtUtc;
+            session.LastDownloadedBytes = 0;
+            session.LastAttemptHadProgress = false;
+            session.LastNoProgressDuration = TimeSpan.Zero;
+
+            if (attempt > 1 && session.Elapsed >= SoftBudget && !previousAttemptHadProgress)
+            {
+                Log.Warning("[DUPDATE] 软预算已耗尽且无有效进度，终止重试。attempt={Attempt} protocol={Protocol} elapsed={Elapsed}",
+                    attempt, session.Protocol, session.Elapsed);
+                break;
+            }
+
+            try
+            {
+                using var httpClient = CreateHttpClient(session.Protocol);
+                await UpdateDalamud(refreshVersionInfo, session, httpClient).ConfigureAwait(false);
+                SaveProtocolState(session.Protocol);
+                return new UpdateExecutionResult(true, null);
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                var errorKind = ClassifyError(ex);
+                session.Elapsed = DateTime.UtcNow - session.StartedAtUtc;
+
+                Log.Error(ex,
+                    "[DUPDATE] 更新失败 attempt={Attempt} protocol={Protocol} errorKind={ErrorKind} fallbackTriggered={FallbackTriggered} noProgressDuration={NoProgressDuration} elapsed={Elapsed}",
+                    attempt,
+                    session.Protocol,
+                    errorKind,
+                    fallbackTriggered,
+                    session.LastNoProgressDuration,
+                    session.Elapsed);
+
+                if (errorKind == UpdateErrorKind.NonRetryable)
+                    break;
+
+                if (ShouldFallbackProtocol(session, errorKind))
+                {
+                    session.Protocol = HttpProtocol.Http11;
+                    session.ProtocolSwitchCount++;
+                    fallbackTriggered = true;
+                    SetLoadingDetail("自动切换兼容模式重试...");
+                    Log.Warning("[DUPDATE] 自动切换兼容模式重试。attempt={Attempt} protocol={Protocol}", attempt, session.Protocol);
+                }
+
+                var delay = ComputeBackoffDelay(attempt);
+                await Task.Delay(delay).ConfigureAwait(false);
+            }
+        }
+
+        return new UpdateExecutionResult(false, lastException);
+    }
+
+    private HttpClient CreateHttpClient(HttpProtocol protocol)
+    {
+        var requestVersion = protocol == HttpProtocol.Http11 ? HttpVersion.Version11 : HttpVersion.Version20;
+        var versionPolicy  = protocol == HttpProtocol.Http11 ? HttpVersionPolicy.RequestVersionOrLower : HttpVersionPolicy.RequestVersionOrHigher;
+
+        var client = XLHttpClientFactory.Create(MetadataRequestTimeout, 50, DecompressionMethods.All, requestVersion, versionPolicy);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("XIVLauncherCN");
+
+        if (!string.IsNullOrWhiteSpace(this.githubToken))
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.githubToken);
+
+        return client;
+    }
+
+    private HttpClient CreateDalamudDownloadHttpClient(HttpProtocol protocol)
+    {
+        var client = CreateHttpClient(protocol);
+        client.Timeout = DalamudDownloadTimeout;
+        return client;
+    }
+
+    private HttpProtocol ResolveInitialProtocol()
+    {
+        switch (updateHttpMode)
+        {
+            case DalamudUpdateHttpMode.Http11:
+                return HttpProtocol.Http11;
+
+            case DalamudUpdateHttpMode.Http2:
+                return HttpProtocol.Http2;
+
+            case DalamudUpdateHttpMode.Auto:
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+        var remembered = TryLoadProtocolState();
+        if (remembered != null && DateTime.UtcNow - remembered.TimestampUtc <= ProtocolMemoryTtl)
+            return remembered.Protocol;
+
+        return HttpProtocol.Http2;
+    }
+
+    private bool ShouldFallbackProtocol(UpdateSessionContext session, UpdateErrorKind errorKind)
+    {
+        if (session.UpdateMode != DalamudUpdateHttpMode.Auto)
+            return false;
+
+        if (session.Protocol != HttpProtocol.Http2)
+            return false;
+
+        if (session.ProtocolSwitchCount >= MaxProtocolSwitchesPerRun)
+            return false;
+
+        return errorKind == UpdateErrorKind.Retryable;
+    }
+
+    private static UpdateErrorKind ClassifyError(Exception ex)
+    {
+        var current = ex;
+
+        while (true)
+        {
+            switch (current)
+            {
+                case DalamudIntegrityException or InvalidDataException:
+                    return UpdateErrorKind.NonRetryable;
+                case TimeoutException:
+                case TaskCanceledException or OperationCanceledException:
+                    return UpdateErrorKind.Retryable;
+                case UnauthorizedAccessException:
+                    return UpdateErrorKind.NonRetryable;
+                case HttpRequestException httpRequestException:
+                    switch (httpRequestException.StatusCode)
+                    {
+                        case HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden or HttpStatusCode.NotFound:
+                            return UpdateErrorKind.NonRetryable;
+
+                        case HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable or HttpStatusCode.GatewayTimeout:
+                            return UpdateErrorKind.Retryable;
+                    }
+
+                    if (httpRequestException.InnerException is TimeoutException)
+                        return UpdateErrorKind.Retryable;
+
+                    break;
+                case IOException ioException:
+                    return IsRetryableIOException(ioException)
+                        ? UpdateErrorKind.Retryable
+                        : UpdateErrorKind.NonRetryable;
+            }
+
+            if (current.InnerException != null)
+            {
+                current = current.InnerException;
+                continue;
+            }
+
+            return UpdateErrorKind.Retryable;
+        }
+    }
+
+    private static TimeSpan ComputeBackoffDelay(int attempt)
+    {
+        var exponent = Math.Min(attempt - 1, 6);
+        var baseSeconds = Math.Min(BackoffBaseSeconds * Math.Pow(2, exponent), BackoffMaxSeconds);
+        var jitterFactor = 1 + (Random.Shared.NextDouble() * BackoffJitterRatio);
+        return TimeSpan.FromSeconds(baseSeconds * jitterFactor);
+    }
+
+    private static bool IsRetryableIOException(IOException ex)
+    {
+        return ex is not
+            (
+                DirectoryNotFoundException
+                or DriveNotFoundException
+                or PathTooLongException
+                or FileNotFoundException
+            );
+    }
+
+    private ProtocolStateDto? TryLoadProtocolState()
+    {
+        try
+        {
+            if (!protocolStateFile.Exists)
+                return null;
+
+            var json = File.ReadAllText(protocolStateFile.FullName, Encoding.UTF8);
+            return System.Text.Json.JsonSerializer.Deserialize<ProtocolStateDto>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void SaveProtocolState(HttpProtocol protocol)
+    {
+        try
+        {
+            if (protocolStateFile.Directory is { Exists: false } stateDirectory)
+                stateDirectory.Create();
+
+            var dto = new ProtocolStateDto
+            {
+                Protocol     = protocol,
+                TimestampUtc = DateTime.UtcNow,
+                Version      = Version
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(dto, StateJsonOptions);
+            File.WriteAllText(protocolStateFile.FullName, json, Utf8WithoutBom);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "[DUPDATE] 写入协议记忆失败，不影响主流程");
+        }
+    }
+
+    private sealed class UpdateSessionContext
+    {
+        public int                   Attempt;
+        public DateTime              StartedAtUtc;
+        public TimeSpan              Elapsed;
+        public HttpProtocol          Protocol;
+        public DalamudUpdateHttpMode UpdateMode;
+        public int                   ProtocolSwitchCount;
+        public bool                  LastAttemptHadProgress;
+        public long                  LastDownloadedBytes;
+        public TimeSpan              LastNoProgressDuration;
+    }
+
+    private sealed class UpdateExecutionResult(bool isSuccess, Exception? lastException)
+    {
+        public bool       IsSuccess     { get; } = isSuccess;
+        public Exception? LastException { get; } = lastException;
+    }
+
+    private sealed class ProtocolStateDto
+    {
+        public HttpProtocol Protocol { get; set; }
+
+        public DateTime TimestampUtc { get; set; }
+
+        public string? Version { get; set; }
+    }
+
+    private enum HttpProtocol
+    {
+        Http2,
+        Http11
+    }
+
+    private enum UpdateErrorKind
+    {
+        Retryable,
+        NonRetryable
+    }
+
+    #endregion
+
     public enum DownloadState
     {
         Unknown,
@@ -968,6 +1147,26 @@ public class DalamudUpdater
     private const string RELEASE_PACKAGE_ASSET = "latest.7z";
 
     private const string RELEASE_HASHES_ASSET = "hashes.json";
+
+    private const int MaxAttempts = 8;
+
+    private const int MaxProtocolSwitchesPerRun = 1;
+
+    private const double BackoffBaseSeconds = 1;
+
+    private const double BackoffMaxSeconds = 15;
+
+    private const double BackoffJitterRatio = 0.3;
+
+    private static readonly TimeSpan SoftBudget = TimeSpan.FromMinutes(8);
+
+    private static readonly TimeSpan NoProgressTimeout = TimeSpan.FromSeconds(45);
+
+    private static readonly TimeSpan MetadataRequestTimeout = TimeSpan.FromSeconds(20);
+
+    private static readonly TimeSpan ProtocolMemoryTtl = TimeSpan.FromHours(24);
+
+    private static readonly TimeSpan DalamudDownloadTimeout = TimeSpan.FromMinutes(10);
 
     #endregion
 }

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -132,7 +132,7 @@ public class DalamudUpdater
             var paths                  = PreparePaths();
             var currentVersionVerified = await UpdateDalamudCoreAsync(paths.addonPath, paths.currentVersionPath, session, httpClient);
             await UpdateRuntimeAsync(httpClient);
-            await UpdateAssetsAsync();
+            await UpdateAssetsAsync(session.Protocol, session);
 
             if (!currentVersionVerified && !CheckDalamudIntegrity(paths.currentVersionPath))
                 throw new DalamudIntegrityException("完整性验证最终失败");
@@ -203,6 +203,9 @@ public class DalamudUpdater
         catch (Exception ex)
         {
             Log.Error(ex, "[DUPDATE] 下载 Dalamud 本体失败");
+            if (ClassifyError(ex) == UpdateErrorKind.Retryable)
+                throw;
+
             throw new DalamudIntegrityException("下载 Dalamud 失败", ex);
         }
     }
@@ -219,7 +222,7 @@ public class DalamudUpdater
             cancellationToken: default
         ).ConfigureAwait(false);
 
-    private async Task UpdateAssetsAsync()
+    private async Task UpdateAssetsAsync(HttpProtocol protocol, UpdateSessionContext session)
     {
         Log.Information("[DUPDATE] 开始验证资源文件完整性");
 
@@ -228,13 +231,16 @@ public class DalamudUpdater
 
         try
         {
-            var assetResult = await AssetManager.EnsureAssets(this, assetDirectory).ConfigureAwait(true);
+            var assetResult = await AssetManager.EnsureAssets(this, assetDirectory, protocol, session).ConfigureAwait(true);
             AssetDirectory = assetResult.AssetDir;
             Log.Information("[DUPDATE] 资源文件验证完成: {Path}", AssetDirectory.FullName);
         }
         catch (Exception ex)
         {
             Log.Error(ex, "[DUPDATE] 资源文件验证失败");
+            if (ClassifyError(ex) == UpdateErrorKind.Retryable)
+                throw;
+
             throw new DalamudIntegrityException("资源文件验证失败", ex);
         }
     }
@@ -655,10 +661,7 @@ public class DalamudUpdater
         using var downloader = new HttpClientDownloadWithProgress(files, httpClient, NoProgressTimeout);
         downloader.ProgressChanged += (size, downloaded, progress) =>
         {
-            var hadProgress = downloaded > session.LastDownloadedBytes;
-            session.LastAttemptHadProgress = session.LastAttemptHadProgress || hadProgress;
-            session.LastDownloadedBytes    = downloaded;
-            session.LastNoProgressDuration = hadProgress ? TimeSpan.Zero : NoProgressTimeout;
+            session.MarkProgress();
             ReportLoadingProgressCore(size, downloaded, progress);
         };
 
@@ -814,11 +817,10 @@ public class DalamudUpdater
         }
     }
 
-    public async Task DownloadFile(string url, string path)
+    internal async Task DownloadFile(string url, string path, HttpProtocol protocol, UpdateSessionContext session)
     {
-        using var httpClient = CreateHttpClient(ResolveInitialProtocol());
+        using var httpClient = CreateHttpClient(protocol);
         httpClient.Timeout = DalamudDownloadTimeout;
-        var session = new UpdateSessionContext { Protocol = ResolveInitialProtocol() };
         await DownloadFiles([(url, path)], httpClient, session).ConfigureAwait(false);
     }
 
@@ -870,11 +872,9 @@ public class DalamudUpdater
         for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
             var previousAttemptHadProgress = session.LastAttemptHadProgress;
-            session.Attempt            = attempt;
-            session.Elapsed            = DateTime.UtcNow - session.StartedAtUtc;
-            session.LastDownloadedBytes = 0;
-            session.LastAttemptHadProgress = false;
-            session.LastNoProgressDuration = TimeSpan.Zero;
+            session.Attempt = attempt;
+            session.Elapsed = DateTime.UtcNow - session.StartedAtUtc;
+            session.BeginAttempt();
 
             if (attempt > 1 && session.Elapsed >= SoftBudget && !previousAttemptHadProgress)
             {
@@ -1087,17 +1087,39 @@ public class DalamudUpdater
         }
     }
 
-    private sealed class UpdateSessionContext
+    internal sealed class UpdateSessionContext
     {
+        private long lastProgressUtcTicks;
+        private int  lastAttemptHadProgress;
+
         public int                   Attempt;
         public DateTime              StartedAtUtc;
         public TimeSpan              Elapsed;
         public HttpProtocol          Protocol;
         public DalamudUpdateHttpMode UpdateMode;
         public int                   ProtocolSwitchCount;
-        public bool                  LastAttemptHadProgress;
-        public long                  LastDownloadedBytes;
-        public TimeSpan              LastNoProgressDuration;
+        public bool                  LastAttemptHadProgress => Volatile.Read(ref lastAttemptHadProgress) != 0;
+
+        public TimeSpan LastNoProgressDuration
+        {
+            get
+            {
+                var progressUtcTicks = Interlocked.Read(ref this.lastProgressUtcTicks);
+                return progressUtcTicks <= 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Math.Max(0, DateTime.UtcNow.Ticks - progressUtcTicks));
+            }
+        }
+
+        public void BeginAttempt()
+        {
+            Volatile.Write(ref lastAttemptHadProgress, 0);
+            Interlocked.Exchange(ref lastProgressUtcTicks, DateTime.UtcNow.Ticks);
+        }
+
+        public void MarkProgress()
+        {
+            Volatile.Write(ref lastAttemptHadProgress, 1);
+            Interlocked.Exchange(ref lastProgressUtcTicks, DateTime.UtcNow.Ticks);
+        }
     }
 
     private sealed class UpdateExecutionResult(bool isSuccess, Exception? lastException)
@@ -1115,7 +1137,7 @@ public class DalamudUpdater
         public string? Version { get; set; }
     }
 
-    private enum HttpProtocol
+    internal enum HttpProtocol
     {
         Http2,
         Http11

--- a/src/XIVLauncher.Common/Http/XLHttpClientFactory.cs
+++ b/src/XIVLauncher.Common/Http/XLHttpClientFactory.cs
@@ -10,7 +10,9 @@ public static class XLHttpClientFactory
     (
         TimeSpan             connectTimeout,
         int                  maxConnectionsPerServer,
-        DecompressionMethods automaticDecompression
+        DecompressionMethods automaticDecompression,
+        Version?             defaultRequestVersion = null,
+        HttpVersionPolicy    defaultVersionPolicy  = HttpVersionPolicy.RequestVersionOrHigher
     )
     {
         var client = new HttpClient
@@ -30,8 +32,8 @@ public static class XLHttpClientFactory
             }
         );
 
-        client.DefaultRequestVersion = HttpVersion.Version20;
-        client.DefaultVersionPolicy  = HttpVersionPolicy.RequestVersionOrHigher;
+        client.DefaultRequestVersion = defaultRequestVersion ?? HttpVersion.Version20;
+        client.DefaultVersionPolicy  = defaultVersionPolicy;
         return client;
     }
 }

--- a/src/XIVLauncher.Common/Util/HttpClientWithProgress.cs
+++ b/src/XIVLauncher.Common/Util/HttpClientWithProgress.cs
@@ -17,6 +17,8 @@ namespace XIVLauncher.Common.Util;
 public class HttpClientDownloadWithProgress : IDisposable
 {
     private readonly HttpClient                  httpClient;
+    private readonly bool                        ownsHttpClient;
+    private readonly TimeSpan?                   noProgressTimeout;
     private readonly (string Url, string Path)[] downloads;
     private readonly long[]                      actualDownloadedSizes;
     private readonly long[]                      reportedSizes;
@@ -25,7 +27,12 @@ public class HttpClientDownloadWithProgress : IDisposable
     private long totalDownloadedSize;
     private long totalSize;
 
-    public HttpClientDownloadWithProgress(IReadOnlyList<(string Url, string Path)> downloads)
+    public HttpClientDownloadWithProgress(IReadOnlyList<(string Url, string Path)> downloads, TimeSpan? noProgressTimeout = null)
+        : this(downloads, null, noProgressTimeout)
+    {
+    }
+
+    public HttpClientDownloadWithProgress(IReadOnlyList<(string Url, string Path)> downloads, HttpClient? httpClient, TimeSpan? noProgressTimeout = null)
     {
         if (downloads.Count == 0)
             throw new ArgumentException("下载列表不能为空", nameof(downloads));
@@ -36,15 +43,29 @@ public class HttpClientDownloadWithProgress : IDisposable
         reportedSizes         = new long[downloads.Count];
         totalSizes            = new long[downloads.Count];
 
-        httpClient         = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), MAX_CONNECTIONS_PER_SERVER, DecompressionMethods.All);
-        httpClient.Timeout = TimeSpan.FromMinutes(10);
-        httpClient.DefaultRequestHeaders.Add("User-Agent", PlatformHelpers.GetVersion());
+        this.noProgressTimeout = noProgressTimeout;
+
+        if (httpClient != null)
+        {
+            this.httpClient  = httpClient;
+            ownsHttpClient = false;
+        }
+        else
+        {
+            this.httpClient  = XLHttpClientFactory.Create(TimeSpan.FromSeconds(5), MAX_CONNECTIONS_PER_SERVER, DecompressionMethods.All);
+            this.httpClient.Timeout = TimeSpan.FromMinutes(10);
+            this.httpClient.DefaultRequestHeaders.Add("User-Agent", PlatformHelpers.GetVersion());
+            ownsHttpClient = true;
+        }
     }
 
     #region Disposal
 
-    public void Dispose() =>
-        httpClient?.Dispose();
+    public void Dispose()
+    {
+        if (ownsHttpClient)
+            httpClient?.Dispose();
+    }
 
     #endregion
 
@@ -121,7 +142,7 @@ public class HttpClientDownloadWithProgress : IDisposable
 
         while (true)
         {
-            var bytesRead = await contentStream.ReadAsync(buffer).ConfigureAwait(false);
+            var bytesRead = await ReadWithNoProgressTimeoutAsync(contentStream, buffer.AsMemory(0, buffer.Length)).ConfigureAwait(false);
 
             if (bytesRead == 0)
             {
@@ -236,7 +257,7 @@ public class HttpClientDownloadWithProgress : IDisposable
 
                 while (true)
                 {
-                    var bytesRead = await contentStream.ReadAsync(buffer.AsMemory(0, BUFFER_SIZE)).ConfigureAwait(false);
+                    var bytesRead = await ReadWithNoProgressTimeoutAsync(contentStream, buffer.AsMemory(0, BUFFER_SIZE)).ConfigureAwait(false);
 
                     if (bytesRead == 0)
                         break;
@@ -265,6 +286,23 @@ public class HttpClientDownloadWithProgress : IDisposable
         finally
         {
             ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task<int> ReadWithNoProgressTimeoutAsync(Stream contentStream, Memory<byte> buffer)
+    {
+        if (!noProgressTimeout.HasValue)
+            return await contentStream.ReadAsync(buffer).ConfigureAwait(false);
+
+        using var cts = new CancellationTokenSource(noProgressTimeout.Value);
+
+        try
+        {
+            return await contentStream.ReadAsync(buffer, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new TimeoutException($"下载连接已中断，连续 {noProgressTimeout.Value.TotalSeconds:0} 秒未收到任何数据。");
         }
     }
 

--- a/src/XIVLauncher/Settings/LauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/LauncherSettingsV3.cs
@@ -184,24 +184,6 @@ public sealed class LauncherSettingsV3
     } = 0;
 
     /// <summary>
-    ///     Dalamud 更新连接超时（秒）
-    /// </summary>
-    public int DalamudUpdateTimeoutSeconds
-    {
-        get;
-        set => Set(ref field, value);
-    } = 3;
-
-    /// <summary>
-    ///     Dalamud 更新最大重试次数
-    /// </summary>
-    public int DalamudUpdateMaxRetries
-    {
-        get;
-        set => Set(ref field, value);
-    } = 3;
-
-    /// <summary>
     ///     Dalamud 更新 HTTP 协议策略
     /// </summary>
     public DalamudUpdateHttpMode DalamudUpdateHttpMode

--- a/src/XIVLauncher/Settings/LauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/LauncherSettingsV3.cs
@@ -183,6 +183,33 @@ public sealed class LauncherSettingsV3
         set => Set(ref field, value);
     } = 0;
 
+    /// <summary>
+    ///     Dalamud 更新连接超时（秒）
+    /// </summary>
+    public int DalamudUpdateTimeoutSeconds
+    {
+        get;
+        set => Set(ref field, value);
+    } = 3;
+
+    /// <summary>
+    ///     Dalamud 更新最大重试次数
+    /// </summary>
+    public int DalamudUpdateMaxRetries
+    {
+        get;
+        set => Set(ref field, value);
+    } = 3;
+
+    /// <summary>
+    ///     Dalamud 更新 HTTP 协议策略
+    /// </summary>
+    public DalamudUpdateHttpMode DalamudUpdateHttpMode
+    {
+        get;
+        set => Set(ref field, value);
+    } = DalamudUpdateHttpMode.Auto;
+
     #endregion
 
     #region 插件/扩展配置

--- a/src/XIVLauncher/Startup/StartupOrchestrator.cs
+++ b/src/XIVLauncher/Startup/StartupOrchestrator.cs
@@ -307,7 +307,10 @@ public class StartupOrchestrator
                 new(Path.Combine(Paths.RoamingPath, "addon")),
                 new(Path.Combine(Paths.RoamingPath, "runtime")),
                 new(Path.Combine(Paths.RoamingPath, "dalamudAssets")),
-                context.Settings.GitHubToken
+                context.Settings.GitHubToken,
+                context.Settings.DalamudUpdateTimeoutSeconds,
+                context.Settings.DalamudUpdateMaxRetries,
+                context.Settings.DalamudUpdateHttpMode
             );
 
             if (dalamudRunnerOverride != null)

--- a/src/XIVLauncher/Startup/StartupOrchestrator.cs
+++ b/src/XIVLauncher/Startup/StartupOrchestrator.cs
@@ -308,8 +308,6 @@ public class StartupOrchestrator
                 new(Path.Combine(Paths.RoamingPath, "runtime")),
                 new(Path.Combine(Paths.RoamingPath, "dalamudAssets")),
                 context.Settings.GitHubToken,
-                context.Settings.DalamudUpdateTimeoutSeconds,
-                context.Settings.DalamudUpdateMaxRetries,
                 context.Settings.DalamudUpdateHttpMode
             );
 

--- a/src/XIVLauncher/Windows/SettingsWindow.xaml
+++ b/src/XIVLauncher/Windows/SettingsWindow.xaml
@@ -572,6 +572,88 @@
                                                  IsChecked="{Binding UseDllInjectLoadMethod}"
                                                  ToolTip="通过 DLL 注入方式加载 Dalamud, 兼容性取决于本机环境。"
                                                  Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" />
+                                 </StackPanel>
+                            </materialDesign:Card>
+
+                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="更新设置"
+                                       Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+                                       FontWeight="Medium"
+                                       Margin="0,24,0,16" />
+
+                            <materialDesign:Card Style="{StaticResource SettingCardStyle}">
+                                <StackPanel>
+                                    <Grid Margin="0,0,0,24">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新超时"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="控制 Dalamud 更新请求连接超时时间（1-30 秒）"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Right">
+                                            <TextBox Width="70" Text="{Binding DalamudUpdateTimeoutSeconds}"
+                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="秒"
+                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid Margin="0,0,0,24">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新重试次数"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="控制 Dalamud 更新失败后的重试次数（1-10 次）"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Right">
+                                            <TextBox Width="70" Text="{Binding DalamudUpdateMaxRetries}"
+                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="次"
+                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" MinWidth="180" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="更新协议"
+                                                       FontSize="15" />
+                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                                       Text="Auto: 先 HTTP/2，超时后回退 HTTP/1.1"
+                                                       Opacity="0.7"
+                                                       FontSize="12" />
+                                        </StackPanel>
+                                        <ComboBox Grid.Column="1" SelectedIndex="{Binding DalamudUpdateHttpModeIndex}"
+                                                  VerticalAlignment="Center"
+                                                  Foreground="{DynamicResource MaterialDesign.Brush.Foreground}">
+                                            <ComboBoxItem Content="Auto" />
+                                            <ComboBoxItem Content="HTTP/2" />
+                                            <ComboBoxItem Content="HTTP/1.1" />
+                                        </ComboBox>
+                                    </Grid>
                                 </StackPanel>
                             </materialDesign:Card>
 

--- a/src/XIVLauncher/Windows/SettingsWindow.xaml
+++ b/src/XIVLauncher/Windows/SettingsWindow.xaml
@@ -582,56 +582,6 @@
 
                             <materialDesign:Card Style="{StaticResource SettingCardStyle}">
                                 <StackPanel>
-                                    <Grid Margin="0,0,0,24">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                       Text="更新超时"
-                                                       FontSize="15" />
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                       Text="控制 Dalamud 更新请求连接超时时间（1-30 秒）"
-                                                       Opacity="0.7"
-                                                       FontSize="12" />
-                                        </StackPanel>
-                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
-                                                    VerticalAlignment="Center"
-                                                    HorizontalAlignment="Right">
-                                            <TextBox Width="70" Text="{Binding DalamudUpdateTimeoutSeconds}"
-                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="秒"
-                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
-                                        </StackPanel>
-                                    </Grid>
-
-                                    <Grid Margin="0,0,0,24">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-                                        <StackPanel VerticalAlignment="Center" Margin="0,0,16,0">
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                       Text="更新重试次数"
-                                                       FontSize="15" />
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                       Text="控制 Dalamud 更新失败后的重试次数（1-10 次）"
-                                                       Opacity="0.7"
-                                                       FontSize="12" />
-                                        </StackPanel>
-                                        <StackPanel Grid.Column="1" Orientation="Horizontal"
-                                                    VerticalAlignment="Center"
-                                                    HorizontalAlignment="Right">
-                                            <TextBox Width="70" Text="{Binding DalamudUpdateMaxRetries}"
-                                                     Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                                     VerticalAlignment="Center" HorizontalContentAlignment="Right" />
-                                            <TextBlock Foreground="{DynamicResource MaterialDesign.Brush.Foreground}" Text="次"
-                                                       Margin="8,0,0,0" VerticalAlignment="Center" Opacity="0.7" />
-                                        </StackPanel>
-                                    </Grid>
-
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />

--- a/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
@@ -157,6 +157,24 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         }
     } = true;
 
+    public decimal? DalamudUpdateTimeoutSeconds
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
+    public decimal? DalamudUpdateMaxRetries
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
+    public int DalamudUpdateHttpModeIndex
+    {
+        get;
+        set => SetProperty(ref field, value);
+    }
+
     public string LaunchArgs
     {
         get;
@@ -318,6 +336,9 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         UseEntryPointLoadMethod                     = App.Settings.DalamudLoadMethod != DalamudLoadMethod.DllInject;
         EnableHooks                                 = App.Settings.DalamudEnabled;
         EnableDcTravel                              = true;
+        DalamudUpdateTimeoutSeconds                 = App.Settings.DalamudUpdateTimeoutSeconds;
+        DalamudUpdateMaxRetries                     = App.Settings.DalamudUpdateMaxRetries;
+        DalamudUpdateHttpModeIndex                  = (int)App.Settings.DalamudUpdateHttpMode;
         LaunchArgs                                  = App.Settings.AdditionalLaunchArgs ?? string.Empty;
         DpiAwarenessIndex                           = (int)App.Settings.DPIAwareness;
         VersionLabelText                            = $"XIVLauncher - v{AppUtil.GetAssemblyVersion()}";
@@ -350,6 +371,11 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         var addonEntries          = AddonEntries.ToList();
         var patchAcquisitionMethod = (AcquisitionMethod)PatchAcquisitionIndex;
         var dalamudLoadMethod      = UseDllInjectLoadMethod ? DalamudLoadMethod.DllInject : DalamudLoadMethod.EntryPoint;
+        var dalamudUpdateTimeoutSeconds = Math.Clamp((int)(DalamudUpdateTimeoutSeconds ?? 3), 1, 30);
+        var dalamudUpdateMaxRetries     = Math.Clamp((int)(DalamudUpdateMaxRetries     ?? 3), 1, 10);
+        var dalamudUpdateHttpMode       = Enum.IsDefined(typeof(DalamudUpdateHttpMode), DalamudUpdateHttpModeIndex)
+            ? (DalamudUpdateHttpMode)DalamudUpdateHttpModeIndex
+            : DalamudUpdateHttpMode.Auto;
         var dpiAwareness           = (DPIAwareness)DpiAwarenessIndex;
         var speedLimitBytes        = (long)((SpeedLimitMb ?? 0) * BYTES_TO_MB);
 
@@ -389,6 +415,9 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
                 settings.DalamudInjectionDelayMS             = DalamudInjectionDelayMs ?? 0;
                 settings.ManualInjectDelayMs                 = ManualInjectDelayMs     ?? 0;
                 settings.DalamudLoadMethod                   = dalamudLoadMethod;
+                settings.DalamudUpdateTimeoutSeconds         = dalamudUpdateTimeoutSeconds;
+                settings.DalamudUpdateMaxRetries             = dalamudUpdateMaxRetries;
+                settings.DalamudUpdateHttpMode               = dalamudUpdateHttpMode;
                 settings.AdditionalLaunchArgs                = LaunchArgs;
                 settings.DPIAwareness                        = dpiAwareness;
                 settings.SpeedLimitBytes                     = speedLimitBytes;
@@ -396,6 +425,10 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
                 settings.CredType                            = credTypeApplyResult.AppliedCredType;
             }
         );
+
+        DalamudUpdateTimeoutSeconds = dalamudUpdateTimeoutSeconds;
+        DalamudUpdateMaxRetries     = dalamudUpdateMaxRetries;
+        DalamudUpdateHttpModeIndex  = (int)dalamudUpdateHttpMode;
 
         SelectedCredType = credTypeApplyResult.AppliedCredType;
 

--- a/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsWindowViewModel.cs
@@ -157,18 +157,6 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         }
     } = true;
 
-    public decimal? DalamudUpdateTimeoutSeconds
-    {
-        get;
-        set => SetProperty(ref field, value);
-    }
-
-    public decimal? DalamudUpdateMaxRetries
-    {
-        get;
-        set => SetProperty(ref field, value);
-    }
-
     public int DalamudUpdateHttpModeIndex
     {
         get;
@@ -336,8 +324,6 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         UseEntryPointLoadMethod                     = App.Settings.DalamudLoadMethod != DalamudLoadMethod.DllInject;
         EnableHooks                                 = App.Settings.DalamudEnabled;
         EnableDcTravel                              = true;
-        DalamudUpdateTimeoutSeconds                 = App.Settings.DalamudUpdateTimeoutSeconds;
-        DalamudUpdateMaxRetries                     = App.Settings.DalamudUpdateMaxRetries;
         DalamudUpdateHttpModeIndex                  = (int)App.Settings.DalamudUpdateHttpMode;
         LaunchArgs                                  = App.Settings.AdditionalLaunchArgs ?? string.Empty;
         DpiAwarenessIndex                           = (int)App.Settings.DPIAwareness;
@@ -371,8 +357,6 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
         var addonEntries          = AddonEntries.ToList();
         var patchAcquisitionMethod = (AcquisitionMethod)PatchAcquisitionIndex;
         var dalamudLoadMethod      = UseDllInjectLoadMethod ? DalamudLoadMethod.DllInject : DalamudLoadMethod.EntryPoint;
-        var dalamudUpdateTimeoutSeconds = Math.Clamp((int)(DalamudUpdateTimeoutSeconds ?? 3), 1, 30);
-        var dalamudUpdateMaxRetries     = Math.Clamp((int)(DalamudUpdateMaxRetries     ?? 3), 1, 10);
         var dalamudUpdateHttpMode       = Enum.IsDefined(typeof(DalamudUpdateHttpMode), DalamudUpdateHttpModeIndex)
             ? (DalamudUpdateHttpMode)DalamudUpdateHttpModeIndex
             : DalamudUpdateHttpMode.Auto;
@@ -415,8 +399,6 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
                 settings.DalamudInjectionDelayMS             = DalamudInjectionDelayMs ?? 0;
                 settings.ManualInjectDelayMs                 = ManualInjectDelayMs     ?? 0;
                 settings.DalamudLoadMethod                   = dalamudLoadMethod;
-                settings.DalamudUpdateTimeoutSeconds         = dalamudUpdateTimeoutSeconds;
-                settings.DalamudUpdateMaxRetries             = dalamudUpdateMaxRetries;
                 settings.DalamudUpdateHttpMode               = dalamudUpdateHttpMode;
                 settings.AdditionalLaunchArgs                = LaunchArgs;
                 settings.DPIAwareness                        = dpiAwareness;
@@ -426,8 +408,6 @@ public sealed class SettingsWindowViewModel : INotifyPropertyChanged
             }
         );
 
-        DalamudUpdateTimeoutSeconds = dalamudUpdateTimeoutSeconds;
-        DalamudUpdateMaxRetries     = dalamudUpdateMaxRetries;
         DalamudUpdateHttpModeIndex  = (int)dalamudUpdateHttpMode;
 
         SelectedCredType = credTypeApplyResult.AppliedCredType;


### PR DESCRIPTION
## 变更概述
在部分复杂网络环境下（链路抖动、代理中间层、网关不稳定），HTTP/2 请求可能发生超时，本 PR 主要解决 Dalamud 更新在复杂网络环境下的稳定性问题，并补充可配置的更新策略能力。

本 PR 将更新执行重构为自适应策略，细化异常分类与重试退避，并引入协议记忆机制；同时收敛设置项，仅保留协议策略配置入口。

## 主要改动

### 更新链路重构
- 将更新流程改为自适应执行策略：
  - 处理重试、退避与失败分类
  - 区分可重试与不可重试错误，减少无意义重试
- 强化协议切换逻辑：
  - `Auto` 模式下在满足条件时进行 HTTP/2 与 HTTP/1.1 切换
  - 限制单次运行内协议切换次数
- 引入协议状态记忆：
  - 在本地持久化最近成功协议与时间戳（含 TTL）
  - 后续更新可利用历史成功协议提高首轮成功率
- 保留并强化并发保护：
  - 更新入口继续通过信号量防止重复触发导致状态竞争

### 设置与 UI 调整
- 保留 Dalamud 更新协议模式设置（Auto / HTTP/2 / HTTP/1.1）

## 协议模式说明
- `Auto`：按运行时结果自适应选择协议，并结合协议记忆提升后续稳定性
- `HTTP/2`：固定使用 HTTP/2
- `HTTP/1.1`：固定使用 HTTP/1.1