### PR TITLE
修复wegame手动注入读取提权游戏进程主模块导致的拒绝访问

### DIFF
--- a/src/XIVLauncher/Windows/ViewModel/Main/Flows/GameInjectionFlow.cs
+++ b/src/XIVLauncher/Windows/ViewModel/Main/Flows/GameInjectionFlow.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using Serilog;
+using XIVLauncher.Common.Game;
 using XIVLauncher.Dalamud;
+using XIVLauncher.Login.Models;
 using XIVLauncher.Support;
 using XIVLauncher.Windows.ViewModel.Main.Models;
 using XIVLauncher.Windows.ViewModel.Main.Services;
@@ -36,13 +40,16 @@ public sealed class GameInjectionFlow
             return false;
         }
 
-        var gameExePath = gameProcess.MainModule?.FileName;
-        var gameExeDir = gameExePath == null ?
-                             null :
-                             Path.GetDirectoryName(gameExePath);
+        var gameExePath = TryGetGameExePath(gameProcess);
+        var gameExeDir  = gameExePath == null ?
+                              null :
+                              Path.GetDirectoryName(gameExePath);
         var gamePath = gameExeDir == null ?
                            null :
                            new DirectoryInfo(gameExeDir).Parent;
+
+        if (gamePath?.Exists != true)
+            gamePath = GetConfiguredGamePath();
 
         if (gamePath?.Exists != true)
         {
@@ -90,5 +97,28 @@ public sealed class GameInjectionFlow
 
         dalamudSession.InjectGame(gamePid, noPlugins);
         return true;
+    }
+
+    private static string? TryGetGameExePath
+    (
+        Process gameProcess
+    )
+    {
+        try
+        {
+            return gameProcess.MainModule?.FileName;
+        }
+        catch (Win32Exception ex)
+        {
+            Log.Error(ex, "无法读取游戏进程主模块, 回退到设置中的游戏目录");
+            return null;
+        }
+    }
+
+    private static DirectoryInfo? GetConfiguredGamePath()
+    {
+        var accountType = App.AccountManager.CurrentAccount?.AccountType
+                          ?? App.Settings.SelectedLoginType.ToAccountType(XIVAccountType.Sdo);
+        return App.Settings.GetGamePath(accountType);
     }
 }


### PR DESCRIPTION
wegame下载的游戏如果注入需要提权。